### PR TITLE
Add support for dropping/raising on/ignoring NA data.

### DIFF
--- a/formulaic/materializers/__init__.py
+++ b/formulaic/materializers/__init__.py
@@ -1,9 +1,11 @@
 from .arrow import ArrowMaterializer
 from .base import FormulaMaterializer
 from .pandas import PandasMaterializer
+from .types import NAAction
 
 __all__ = [
     'ArrowMaterializer',
     'FormulaMaterializer',
-    'PandasMaterializer'
+    'NAAction',
+    'PandasMaterializer',
 ]

--- a/formulaic/materializers/arrow.py
+++ b/formulaic/materializers/arrow.py
@@ -9,7 +9,8 @@ class ArrowMaterializer(PandasMaterializer):
     DEFAULT_FOR = ['pyarrow.lib.Table']
 
     @override
-    def _init(self, kwargs):
+    def _init(self, sparse=False):
+        super()._init(sparse=sparse)
         self.__data_context = LazyArrowTableProxy(self.data)
 
     @override

--- a/formulaic/materializers/types/__init__.py
+++ b/formulaic/materializers/types/__init__.py
@@ -1,9 +1,11 @@
+from .enums import NAAction
 from .evaluated_factor import EvaluatedFactor
 from .scoped_factor import ScopedFactor
 from .scoped_term import ScopedTerm
 
 __all__ = [
     'EvaluatedFactor',
+    'NAAction',
     'ScopedFactor',
     'ScopedTerm',
 ]

--- a/formulaic/materializers/types/enums.py
+++ b/formulaic/materializers/types/enums.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class NAAction(Enum):
+    DROP = 'drop'
+    RAISE = 'raise'
+    IGNORE = 'ignore'

--- a/formulaic/model_spec.py
+++ b/formulaic/model_spec.py
@@ -2,16 +2,17 @@ from collections import OrderedDict
 import inspect
 
 from .formula import Formula
-from .materializers import FormulaMaterializer
+from .materializers import FormulaMaterializer, NAAction
 
 
 class ModelSpec:
 
-    def __init__(self, formula, ensure_full_rank=True, structure=None, materializer=None, transforms=None, encoding=None):
+    def __init__(self, formula, ensure_full_rank=True, structure=None, materializer=None, na_action='drop', transforms=None, encoding=None):
         self.formula = Formula.from_spec(formula)
         self.ensure_full_rank = ensure_full_rank
         self.structure = structure
         self.materializer = materializer
+        self.na_action = NAAction(na_action)
         self.transforms = transforms or {}
         self.encoding = encoding or {}
 

--- a/tests/materializers/test_base.py
+++ b/tests/materializers/test_base.py
@@ -77,7 +77,8 @@ class TestFormulaMaterializer:
             ],
             structure=[
                 ('A', {'A'}, ['a'])
-            ]
+            ],
+            drop_rows=[],
         ))) == 1
 
         # Ensure than an exception is raised if input structure > expected structure
@@ -88,7 +89,8 @@ class TestFormulaMaterializer:
                 ],
                 structure=[
                     ('A', {'A'}, ['a'])
-                ]
+                ],
+                drop_rows=[],
             ))
 
         # Ensure that missing columns are imputed
@@ -98,7 +100,8 @@ class TestFormulaMaterializer:
             ],
             structure=[
                 ('A', {'A'}, ['a', 'b'])
-            ]
+            ],
+            drop_rows=[],
         ))[0][-1]) == ['a', 'b']
 
         assert list(list(PandasMaterializer(df)._enforce_structure(
@@ -107,7 +110,8 @@ class TestFormulaMaterializer:
             ],
             structure=[
                 ('A', {'A'}, ['a', 'b'])
-            ]
+            ],
+            drop_rows=[],
         ))[0][-1]) == ['a', 'b']
 
         # Ensure that imputation does not occur if it would be ambiguous
@@ -118,7 +122,8 @@ class TestFormulaMaterializer:
                 ],
                 structure=[
                     ('A', {'A'}, ['a', 'b', 'c'])
-                ]
+                ],
+                drop_rows=[],
             ))
 
         # Ensure that an exception is raised if columns do not match
@@ -129,7 +134,8 @@ class TestFormulaMaterializer:
                 ],
                 structure=[
                     ('A', {'A'}, ['a', 'b', 'c'])
-                ]
+                ],
+                drop_rows=[],
             ))
 
     def test__get_columns_for_term(self):

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -5,15 +5,16 @@ import scipy.sparse as spsparse
 
 from formulaic.errors import FactorEncodingError, FactorEvaluationError
 from formulaic.materializers import PandasMaterializer
-from formulaic.materializers.types import EvaluatedFactor
+from formulaic.materializers.types import EvaluatedFactor, NAAction
 from formulaic.parser.types import Factor
 
 
 PANDAS_TESTS = {
-    'a': (['Intercept', 'a'], ['Intercept', 'a']),
-    'A': (['Intercept', 'A[T.b]', 'A[T.c]'], ['Intercept', 'A[T.a]', 'A[T.b]', 'A[T.c]']),
-    'C(A)': (['Intercept', 'C(A)[T.b]', 'C(A)[T.c]'], ['Intercept', 'C(A)[T.a]', 'C(A)[T.b]', 'C(A)[T.c]']),
-    'a:A': (['Intercept', 'A[T.a]:a', 'A[T.b]:a', 'A[T.c]:a'], ['Intercept', 'A[T.a]:a', 'A[T.b]:a', 'A[T.c]:a']),
+    # '<formula>': (<full_rank_names>, <names>, <full_rank_null_names>, <null_rows>)
+    'a': (['Intercept', 'a'], ['Intercept', 'a'], ['Intercept', 'a'], 2),
+    'A': (['Intercept', 'A[T.b]', 'A[T.c]'], ['Intercept', 'A[T.a]', 'A[T.b]', 'A[T.c]'], ['Intercept', 'A[T.c]'], 2),
+    'C(A)': (['Intercept', 'C(A)[T.b]', 'C(A)[T.c]'], ['Intercept', 'C(A)[T.a]', 'C(A)[T.b]', 'C(A)[T.c]'], ['Intercept', 'C(A)[T.c]'], 3),
+    'a:A': (['Intercept', 'A[T.a]:a', 'A[T.b]:a', 'A[T.c]:a'], ['Intercept', 'A[T.a]:a', 'A[T.b]:a', 'A[T.c]:a'], ['Intercept', 'A[T.a]:a'], 1),
 }
 
 
@@ -22,6 +23,10 @@ class TestPandasMaterializer:
     @pytest.fixture
     def data(self):
         return pandas.DataFrame({'a': [1, 2, 3], 'A': ['a', 'b', 'c']})
+
+    @pytest.fixture
+    def data_with_nulls(self):
+        return pandas.DataFrame({'a': [1, 2, None], 'A': ['a', None, 'c']})
 
     @pytest.fixture
     def materializer(self, data):
@@ -55,6 +60,21 @@ class TestPandasMaterializer:
         assert mm.shape == (3, len(tests[1]))
         assert list(mm.model_spec.feature_names) == tests[1]
 
+    @pytest.mark.parametrize("formula,tests", PANDAS_TESTS.items())
+    def test_na_handling(self, data_with_nulls, formula, tests):
+        mm = PandasMaterializer(data_with_nulls).get_model_matrix(formula)
+        assert isinstance(mm, pandas.DataFrame)
+        assert mm.shape == (tests[3], len(tests[2]))
+        assert list(mm.columns) == tests[2]
+
+        mm = PandasMaterializer(data_with_nulls, na_action='ignore').get_model_matrix(formula)
+        assert isinstance(mm, pandas.DataFrame)
+        assert mm.shape == (3, len(tests[0]) + (-1 if 'A' in formula else 0))
+
+        if formula != 'C(A)':  # C(A) pre-encodes the data, stripping out nulls.
+            with pytest.raises(ValueError):
+                PandasMaterializer(data_with_nulls, na_action='raise').get_model_matrix(formula)
+
     def test_state(self, materializer):
         mm = materializer.get_model_matrix('center(a) - 1')
         assert isinstance(mm, pandas.DataFrame)
@@ -73,24 +93,24 @@ class TestPandasMaterializer:
 
     def test_factor_evaluation_edge_cases(self, materializer):
         # Test that categorical kinds are set if type would otherwise be numerical
-        ev_factor = materializer._evaluate_factor(Factor('a', eval_method='lookup', kind='categorical'), {}, {})
+        ev_factor = materializer._evaluate_factor(Factor('a', eval_method='lookup', kind='categorical'), {}, {}, NAAction.DROP, drop_rows=set())
         assert ev_factor.kind.value == 'categorical'
 
         # Test that other kind mismatches result in an exception
         materializer.factor_cache = {}
         with pytest.raises(FactorEncodingError):
-            materializer._evaluate_factor(Factor('A', eval_method='lookup', kind='numerical'), {}, {})
+            materializer._evaluate_factor(Factor('A', eval_method='lookup', kind='numerical'), {}, {}, NAAction.DROP, drop_rows=[])
 
         # Test that if an encoding has already been determined, that an exception is raised
         # if the new encoding does not match
         materializer.factor_cache = {}
         with pytest.raises(FactorEncodingError):
-            materializer._evaluate_factor(Factor('a', eval_method='lookup', kind='numerical'), {}, {'a': ('categorical', {})})
+            materializer._evaluate_factor(Factor('a', eval_method='lookup', kind='numerical'), {}, {'a': ('categorical', {})}, NAAction.DROP, drop_rows=[])
 
         # Test that invalid (kind == UNKNOWN) factors raise errors
         materializer.factor_cache = {}
         with pytest.raises(FactorEvaluationError):
-            assert materializer._evaluate_factor(Factor('a'), {}, {})
+            assert materializer._evaluate_factor(Factor('a'), {}, {}, NAAction.DROP, drop_rows=set())
 
     def test_categorical_dict_detection(self, materializer):
         assert materializer._is_categorical({'__kind__': 'categorical'})
@@ -106,6 +126,7 @@ class TestPandasMaterializer:
                         kind='constant',
                     ),
                     encoder_state={},
+                    drop_rows=[],
                 )['10']
             ) == [10, 10, 10]
         )

--- a/tests/materializers/transforms/test_encode_categorical.py
+++ b/tests/materializers/transforms/test_encode_categorical.py
@@ -8,8 +8,9 @@ from formulaic.materializers.transforms import encode_categorical
 
 def test_encode_categorical():
     state = {}
+    config = {'sparse': False}
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': True,
@@ -25,7 +26,7 @@ def test_encode_categorical():
 
     with pytest.warns(DataMismatchWarning):
         _compare_formulaic_dict(
-            encode_categorical(data=['a', 'b', 'd', 'a', 'b', 'd'], state=state),
+            encode_categorical(data=['a', 'b', 'd', 'a', 'b', 'd'], state=state, config=config),
             {
                 '__kind__': 'categorical',
                 '__spans_intercept__': True,
@@ -40,7 +41,7 @@ def test_encode_categorical():
         assert state['categories'] == ['a', 'b', 'c']
 
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, reduced_rank=True),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config, reduced_rank=True),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': False,
@@ -54,7 +55,7 @@ def test_encode_categorical():
     assert state['categories'] == ['a', 'b', 'c']
 
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, reduced_rank=False, spans_intercept=False),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config, reduced_rank=False, spans_intercept=False),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': False,
@@ -71,8 +72,9 @@ def test_encode_categorical():
 
 def test_encode_categorical_sparse():
     state = {}
+    config = {'sparse': True}
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config={'sparse': True}),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': True,
@@ -87,7 +89,7 @@ def test_encode_categorical_sparse():
     assert state['categories'] == ['a', 'b', 'c']
 
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config={'sparse': True}, reduced_rank=True),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config, reduced_rank=True),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': False,
@@ -102,7 +104,7 @@ def test_encode_categorical_sparse():
 
     with pytest.warns(DataMismatchWarning):
         _compare_formulaic_dict(
-            encode_categorical(data=['a', 'b', 'd', 'a', 'b', 'd'], state=state, config={'sparse': True}),
+            encode_categorical(data=['a', 'b', 'd', 'a', 'b', 'd'], state=state, config=config),
             {
                 '__kind__': 'categorical',
                 '__spans_intercept__': True,

--- a/tests/utils/test_stateful_transforms.py
+++ b/tests/utils/test_stateful_transforms.py
@@ -3,7 +3,6 @@ from formulaic.utils.stateful_transforms import stateful_eval, stateful_transfor
 
 @stateful_transform
 def dummy_transform(data, state, config):
-    assert config.sparse is False
     if 'data' not in state:
         state['data'] = data
     return state['data']


### PR DESCRIPTION
This patch adds support for dealing with NA data in the dataset, adding some marginal overhead to performance when enabled. To use it, pass `na_action` to the `FormulaMaterializer` subclass of interest, or via the higher-level convenience wrappers. For example:

```
from formulaic import Formula
df = ...
Formula('a + b').get_model_matrix(df, na_action="drop")
```

Valid options for `na_action` are: "drop" (default), "raise" or "ignore". The R names for these are "omit", "error" and "pass", ~~which I am tossing up using instead~~ **These names will be kept**. Current choices are because "drop" is more in line with pandas, "raise" is more Pythonic, and "ignore" was what I originally thought about. [Patsy also appears to use "drop" and "raise"; but doesn't seem to support "ignore"?]

Null checks are performed *after* evaluation of columns, so custom python functions can be used to impute nulls local to a column (soon I will add an `impute` stateful transformation that makes this more natural).

Not included in this patch, but a related effort, is support for performing stateful transformations on the entire dataset before performing the usual model matrix materialisation. This will allow for more sophisticated imputations, such as those involving PCA methods, which require access to the entire original dataset. The resulting state can then be reused in the generation of new model matrices, which is why this approach is a value-add over just expecting users to do the imputation upstream.