### PR TITLE
Replace all instances of '0' with '-1' in formula (not just first)

### DIFF
--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -18,7 +18,7 @@ FORMULA_TO_TOKENS = {
 
     # Test translation of '0'
     '0': ['1', '-', '1'],
-    '0 ~': ['0', '~', '1']
+    '0 ~': ['~', '1']
 }
 
 FORMULA_TO_TERMS = {
@@ -33,6 +33,13 @@ FORMULA_TO_TERMS = {
     '(a + b) - a': ['1', 'b'],
     '(a - a) + b': ['1', 'b'],
     'a + (b - a)': ['1', 'a', 'b'],
+
+    # Check that "0" -> "-1" substitution works as expected
+    '0 + 0': [],
+    '0 + 0 + 1': ['1'],
+    '0 + 0 + 1 + 0': [],
+    '0 - 0': ['1'],
+    '0 ~ 0': ([], ),
 
     # Formula separators
     '~ a + b': (['1', 'a', 'b'], ),
@@ -80,4 +87,8 @@ class TestFormulaParser:
 
     def test_invalid_unary_negation(self):
         with pytest.raises(FormulaParsingError):
-            assert PARSER.get_terms('(-10)')
+            PARSER.get_terms('(-10)')
+
+    def test_invalid_use_of_zero(self):
+        with pytest.raises(FormulaParsingError):
+            PARSER.get_terms('a * 0')


### PR DESCRIPTION
In the current master code, when parsing formulas only the first instance of `0` is replaced with `-1`, and only if preceded with a `+`. This patch fixes this to have the expected behaviour, whereby `0` is replaced everywhere with (the equivalent of) `-1`, and adds unit tests to prevent regressions.

This closes #8 .