### PR TITLE
Improve rigour and error messaging of formula parser.

### DIFF
--- a/formulaic/errors.py
+++ b/formulaic/errors.py
@@ -13,12 +13,24 @@ class FormulaicWarning(Warning):
 
 
 class FormulaInvalidError(FormulaicError):
+    """
+    Provided formula specification is not a valid format.
+    """
     pass
 
 
 class FormulaParsingError(FormulaicError):
+    """
+    An error occured during the parsing of a formula specification.
+    """
     pass
 
+
+class FormulaSyntaxError(FormulaParsingError):
+    """
+    Could not tokenize the nominated formula specification.
+    """
+    pass
 
 # Formula materializer meta-errors
 

--- a/formulaic/parser/__init__.py
+++ b/formulaic/parser/__init__.py
@@ -1,5 +1,6 @@
-from .parser import FormulaParser
+from .parser import FormulaParser, DefaultOperatorResolver
 
 __all__ = [
-    'FormulaParser'
+    'FormulaParser',
+    'DefaultOperatorResolver',
 ]

--- a/formulaic/parser/parser.py
+++ b/formulaic/parser/parser.py
@@ -1,67 +1,21 @@
+import ast
 import itertools
 import functools
+import re
+from typing import List
 
 from formulaic.errors import FormulaParsingError
 
 from .algos.infix_to_ast import infix_to_ast
 from .algos.tokenize import tokenize
-from .types import Factor, Term, Token, Operator
+from .types import Factor, Term, Token, Operator, OperatorResolver
+from .utils import exc_for_token
 
 
 class FormulaParser:
 
-    @property
-    def operators(self):
-
-        def formula_separator_expansion(lhs, rhs):
-            terms = (lhs.to_terms(), rhs.to_terms())
-
-            out = []
-            for termset in terms:
-                if isinstance(termset, tuple):
-                    out.extend(termset)
-                else:
-                    out.append(termset)
-            return tuple(out)
-
-        def nested_product_expansion(parents, nested):
-            terms = parents.to_terms()
-            common = functools.reduce(lambda x, y: x * y, terms)
-            return terms.union({
-                common * term
-                for term in nested.to_terms()
-            })
-
-        def unary_negation(arg):
-            terms = arg.to_terms()
-            if len(terms) > 1 or list(terms)[0] != '0':
-                raise FormulaParsingError("Unary negation is only implemented for '0', where it is substituted for '1'.")
-            return {Term(factors=[Factor('1', eval_method='literal')])}  # pragma: no cover; All zero handling is currently done in the token pre-processor.
-
-        return [
-            Operator("~", arity=2, precedence=-100, associativity=None, to_terms=formula_separator_expansion),
-            Operator("~", arity=1, precedence=-100, associativity=None, fixity='prefix', to_terms=lambda expr: (expr.to_terms(), )),
-            Operator("+", arity=2, precedence=100, associativity='left', to_terms=lambda *args: set(itertools.chain(*[arg.to_terms() for arg in args]))),
-            Operator("-", arity=2, precedence=100, associativity='left', to_terms=lambda left, right: set(set(left.to_terms()).difference(right.to_terms()))),
-            Operator("+", arity=1, precedence=100, associativity='right', fixity='prefix', to_terms=lambda arg: arg.to_terms()),
-            Operator("-", arity=1, precedence=100, associativity='right', fixity='prefix', to_terms=unary_negation),
-            Operator("*", arity=2, precedence=200, associativity='left', to_terms=lambda *args: (
-                {
-                    functools.reduce(lambda x, y: x * y, term)
-                    for term in itertools.product(*[arg.to_terms() for arg in args])
-                }
-                .union(itertools.chain(*[arg.to_terms() for arg in args]))
-            )),
-            Operator("/", arity=2, precedence=200, associativity='left', to_terms=nested_product_expansion),
-            Operator(":", arity=2, precedence=300, associativity='left', to_terms=lambda *args: {
-                functools.reduce(lambda x, y: x * y, term)
-                for term in itertools.product(*[arg.to_terms() for arg in args])
-            }),
-            Operator("**", arity=2, precedence=500, associativity='right', to_terms=lambda arg, power: {
-                functools.reduce(lambda x, y: x * y, term)
-                for term in itertools.product(*[arg.to_terms()] * int(power.token))
-            }),
-        ]
+    def __init__(self, operator_resolver=None):
+        self.operator_resolver = operator_resolver or DefaultOperatorResolver()
 
     def get_tokens(self, formula, *, include_intercept=True):
         tokens = list(tokenize(formula))
@@ -108,7 +62,7 @@ class FormulaParser:
         return tokens
 
     def get_ast(self, formula, *, include_intercept=True):
-        return infix_to_ast(self.get_tokens(formula, include_intercept=include_intercept), operators=self.operators)
+        return infix_to_ast(self.get_tokens(formula, include_intercept=include_intercept), operator_resolver=self.operator_resolver)
 
     def get_terms(self, formula, *, sort=True, include_intercept=True):
         terms = self.get_ast(formula, include_intercept=include_intercept).to_terms()
@@ -120,3 +74,83 @@ class FormulaParser:
                 terms = sorted(terms)
 
         return terms
+
+
+class DefaultOperatorResolver(OperatorResolver):
+
+    @property
+    def operators(self):
+
+        def formula_separator_expansion(lhs, rhs):
+            terms = (lhs.to_terms(), rhs.to_terms())
+
+            out = []
+            for termset in terms:
+                if isinstance(termset, tuple):
+                    out.extend(termset)
+                else:
+                    out.append(termset)
+            return tuple(out)
+
+        def nested_product_expansion(parents, nested):
+            terms = parents.to_terms()
+            common = functools.reduce(lambda x, y: x * y, terms)
+            return terms.union({
+                common * term
+                for term in nested.to_terms()
+            })
+
+        def unary_negation(arg):
+            # TODO: FormulaParser().get_terms('a * ( - b)') Should return `a`
+            terms = arg.to_terms()
+            if len(terms) > 1 or list(terms)[0] != '0':
+                raise FormulaParsingError("Unary negation is only implemented for '0', where it is substituted for '1'.")
+            return {Term(factors=[Factor('1', eval_method='literal')])}  # pragma: no cover; All zero handling is currently done in the token pre-processor.
+
+        def power(arg, power):
+            if not isinstance(power, Token) or power.kind is not Token.Kind.VALUE or not isinstance(ast.literal_eval(power.token), int):
+                raise exc_for_token(power, "The right-hand argument of `**` must be a positive integer.")
+            return {
+                functools.reduce(lambda x, y: x * y, term)
+                for term in itertools.product(*[arg.to_terms()] * int(power.token))
+            }
+
+        return [
+            Operator("~", arity=2, precedence=-100, associativity=None, to_terms=formula_separator_expansion),
+            Operator("~", arity=1, precedence=-100, associativity=None, fixity='prefix', to_terms=lambda expr: (expr.to_terms(), )),
+            Operator("+", arity=2, precedence=100, associativity='left', to_terms=lambda *args: set(itertools.chain(*[arg.to_terms() for arg in args]))),
+            Operator("-", arity=2, precedence=100, associativity='left', to_terms=lambda left, right: set(set(left.to_terms()).difference(right.to_terms()))),
+            Operator("+", arity=1, precedence=100, associativity='right', fixity='prefix', to_terms=lambda arg: arg.to_terms()),
+            Operator("-", arity=1, precedence=100, associativity='right', fixity='prefix', to_terms=unary_negation),
+            Operator("*", arity=2, precedence=200, associativity='left', to_terms=lambda *args: (
+                {
+                    functools.reduce(lambda x, y: x * y, term)
+                    for term in itertools.product(*[arg.to_terms() for arg in args])
+                }
+                .union(itertools.chain(*[arg.to_terms() for arg in args]))
+            )),
+            Operator("/", arity=2, precedence=200, associativity='left', to_terms=nested_product_expansion),
+            Operator(":", arity=2, precedence=300, associativity='left', to_terms=lambda *args: {
+                functools.reduce(lambda x, y: x * y, term)
+                for term in itertools.product(*[arg.to_terms() for arg in args])
+            }),
+            Operator("**", arity=2, precedence=500, associativity='right', to_terms=power),
+        ]
+
+    def resolve(self, token: Token, max_prefix_arity) -> List[Operator]:
+        if token.token in self.operator_table:
+            return super().resolve(token, max_prefix_arity)
+
+        symbol = token.token
+
+        # Apply R-like transformations to operator
+        symbol = re.sub(r'[+\-]*\-[+\-]*', '-', symbol)  # Any sequence of '+' and '-' -> '-'
+        symbol = re.sub(r'[+]{2,}', '+', symbol)  # multiple sequential '+' -> '+'
+
+        if symbol in self.operator_table:
+            return [self._resolve(token, symbol, max_prefix_arity)]
+
+        return [
+            self._resolve(token, sym, max_prefix_arity if i == 0 else 0)
+            for i, sym in enumerate(symbol)
+        ]

--- a/formulaic/parser/types/__init__.py
+++ b/formulaic/parser/types/__init__.py
@@ -1,6 +1,7 @@
 from .ast_node import ASTNode
 from .factor import Factor
 from .operator import Operator
+from .operator_resolver import OperatorResolver
 from .term import Term
 from .token import Token
 
@@ -9,6 +10,7 @@ __all__ = [
     'ASTNode',
     'Factor',
     'Operator',
+    'OperatorResolver',
     'Term',
     'Token'
 ]

--- a/formulaic/parser/types/operator_resolver.py
+++ b/formulaic/parser/types/operator_resolver.py
@@ -1,0 +1,37 @@
+from collections import defaultdict
+from typing import List
+
+from ..utils import exc_for_token
+from .operator import Operator
+from .token import Token
+
+
+class OperatorResolver:
+
+    def __init__(self):
+        self.operator_table = defaultdict(list)
+        for operator in self.operators:
+            self.operator_table[operator.symbol].append(operator)
+        for symbol in self.operator_table:
+            self.operator_table[symbol] = sorted(self.operator_table[symbol], key=lambda op: op.precedence, reverse=True)
+
+    @property
+    def operators(self) -> List[Operator]:
+        return []  # pragma: no cover
+
+    def resolve(self, token: Token, max_prefix_arity) -> List[Operator]:
+        return [self._resolve(token, token.token, max_prefix_arity)]
+
+    def _resolve(self, token: Token, symbol: str, max_prefix_arity: int) -> Operator:
+        if symbol not in self.operator_table:
+            raise exc_for_token(token, f"Unknown operator '{symbol}'.")
+        candidates = [
+            candidate
+            for candidate in self.operator_table[symbol]
+            if max_prefix_arity == 0 and candidate.fixity is Operator.Fixity.PREFIX or max_prefix_arity > 0 and candidate.fixity is not Operator.Fixity.PREFIX
+        ]
+        if not candidates:
+            raise exc_for_token(token, f"Operator `{symbol}` is incorrectly used.")
+        if len(candidates) > 1:
+            raise exc_for_token(token, f"Ambiguous operator `{symbol}`. This is not usually a user error. Please report this!")
+        return candidates[0]

--- a/formulaic/parser/types/token.py
+++ b/formulaic/parser/types/token.py
@@ -19,7 +19,7 @@ class Token:
         self.kind = kind
         self.source = source
         self.source_start = source_start
-        self.source_end = source_end
+        self.source_end = source_end or source_start
 
     @property
     def kind(self):
@@ -76,6 +76,15 @@ class Token:
 
     def flatten(self, str_args=False):
         return str(self) if str_args else self
+
+    def get_source_context(self, colorize=False):
+        if not self.source or self.source_start is None or self.source_end is None:
+            return None
+        if colorize:
+            RED_BOLD = "\x1b[1;31m"
+            RESET = "\x1b[0m"
+            return f"{self.source[:self.source_start]}⧛{RED_BOLD}{self.source[self.source_start:self.source_end+1]}{RESET}⧚{self.source[self.source_end+1:]}"
+        return f"{self.source[:self.source_start]}⧛{self.source[self.source_start:self.source_end+1]}⧚{self.source[self.source_end+1:]}"
 
     def __repr__(self):
         return self.token

--- a/formulaic/parser/utils.py
+++ b/formulaic/parser/utils.py
@@ -1,0 +1,44 @@
+from formulaic.errors import FormulaSyntaxError
+from .types.ast_node import ASTNode
+from .types.token import Token
+
+
+def exc_for_token(token, message, errcls=FormulaSyntaxError):
+    token = __get_token_for_ast(token)
+    token_context = token.get_source_context(colorize=True)
+    if token_context:
+        return errcls(f"{message}\n\n{token_context}")
+    return errcls(message)
+
+
+def exc_for_missing_operator(lhs, rhs, errcls=FormulaSyntaxError):
+    lhs_token, rhs_token, error_token = __get_tokens_for_gap(lhs, rhs)
+    raise exc_for_token(error_token, f"Missing operator between `{lhs_token.token}` and `{rhs_token.token}`.", errcls=errcls)
+
+
+def __get_token_for_ast(ast):
+    if isinstance(ast, Token):
+        return ast
+    lhs_token = ast
+    while isinstance(lhs_token, ASTNode):
+        lhs_token = lhs_token.args[0]
+    rhs_token = ast
+    while isinstance(rhs_token, ASTNode):
+        rhs_token = rhs_token.args[-1]
+    return Token(
+        token=lhs_token.source[lhs_token.source_start:rhs_token.source_end + 1] if lhs_token.source else '',
+        source=lhs_token.source, source_start=lhs_token.source_start, source_end=rhs_token.source_end
+    )
+
+
+def __get_tokens_for_gap(lhs, rhs):
+    lhs_token = lhs
+    while isinstance(lhs_token, ASTNode):
+        lhs_token = lhs_token.args[-1]
+    rhs_token = rhs or lhs
+    while isinstance(rhs_token, ASTNode):
+        rhs_token = rhs_token.args[0]
+    return lhs_token, rhs_token, Token(
+        lhs_token.source[lhs_token.source_start:rhs_token.source_end + 1] if lhs_token.source else '',
+        source=lhs_token.source, source_start=lhs_token.source_start, source_end=rhs_token.source_end
+    )

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     extras_require={
         'arrow': ['pyarrow'],
         'benchmarks': ['patsy', 'rpy2', 'uncertainties'],
-        'test': test_deps
+        'test': test_deps,
     },
 
 )

--- a/tests/parser/algos/test_tokenize.py
+++ b/tests/parser/algos/test_tokenize.py
@@ -1,7 +1,7 @@
 import pytest
 
 from formulaic.parser.algos.tokenize import tokenize
-from formulaic.errors import FormulaParsingError
+from formulaic.errors import FormulaSyntaxError
 
 
 TOKEN_TESTS = {
@@ -20,11 +20,13 @@ TOKEN_TESTS = {
     '"abc" + "def"': ['value:"abc"', 'operator:+', 'value:"def"'],
     '`a|b * 2:a{}`': ["name:a|b * 2:a{}"],
     '{`a|b` @ `b2:1`}': ["python:`a|b` @ `b2:1`"],
+    'I(`a|b`)': ["python:I(`a|b`)"],
     'a + `a+b` + {a / b}': ["name:a", 'operator:+', "name:a+b", 'operator:+', "python:a / b"],
 }
 
 TOKEN_ERRORS = {
-    'a"hello"': [FormulaParsingError, "Unexpected character '\"' following token 'a'."],
+    'a"hello"': [FormulaSyntaxError, "Unexpected character '\"' following token `a`."],
+    '`a': [FormulaSyntaxError, "Formula ended before quote context was closed. Expected: `"],
 }
 
 

--- a/tests/parser/types/test_operator_resolver.py
+++ b/tests/parser/types/test_operator_resolver.py
@@ -1,0 +1,43 @@
+import pytest
+
+from formulaic.errors import FormulaParsingError, FormulaSyntaxError
+from formulaic.parser.types import Operator, OperatorResolver, Token
+
+OPERATOR_PLUS = Operator("+", arity=2, precedence=100, fixity='infix')
+OPERATOR_UNARY_MINUS = Operator("-", arity=1, precedence=100, fixity='prefix')
+OPERATOR_COLON = Operator(":", arity=1, precedence=100, fixity='postfix')
+OPERATOR_COLON_2 = Operator(":", arity=2, precedence=100, fixity='infix')
+
+class DummyOperatorResolver(OperatorResolver):
+
+    @property
+    def operators(self):
+        return [
+            OPERATOR_PLUS,
+            OPERATOR_UNARY_MINUS,
+            OPERATOR_COLON,
+            OPERATOR_COLON_2,
+        ]
+
+
+class TestOperatorResolver:
+
+    @pytest.fixture
+    def resolver(self):
+        return DummyOperatorResolver()
+
+    def test_resolve(self, resolver):
+        assert resolver.resolve(Token('+'), 1)[0] is OPERATOR_PLUS
+        assert resolver.resolve(Token('-'), 0)[0] is OPERATOR_UNARY_MINUS
+
+        with pytest.raises(FormulaSyntaxError):
+            resolver.resolve(Token('@'), 0)
+
+        with pytest.raises(FormulaSyntaxError):
+            resolver.resolve(Token('+'), 0)
+
+        with pytest.raises(FormulaSyntaxError):
+            resolver.resolve(Token('-'), 1)
+
+        with pytest.raises(FormulaParsingError, match="Ambiguous operator `:`"):
+            resolver.resolve(Token(':'), 1)

--- a/tests/parser/types/test_token.py
+++ b/tests/parser/types/test_token.py
@@ -10,7 +10,7 @@ class TestToken:
 
     @pytest.fixture
     def token_b(self):
-        return Token('log(x)', kind='python')
+        return Token('log(x)', kind='python', source='y ~ log(x)', source_start=4, source_end=9)
 
     @pytest.fixture
     def token_c(self):
@@ -66,3 +66,10 @@ class TestToken:
     def test_flatten(self, token_a):
         assert token_a.flatten(str_args=False) is token_a
         assert token_a.flatten(str_args=True) is 'a'
+
+    def test_get_source_context(self, token_a, token_b, token_c):
+        assert token_a.get_source_context() is None
+        assert token_b.get_source_context() == 'y ~ ⧛log(x)⧚'
+        assert token_c.get_source_context() is None
+
+        assert token_b.get_source_context(colorize=True) == 'y ~ ⧛\x1b[1;31mlog(x)\x1b[0m⧚'


### PR DESCRIPTION
This patchset makes the parsing of formulas in formulaic much more robust, and provides users with more helpful error messages when things go wrong.

Formerly, formulaic just assumed that users would write valid formulas, and when they did, it worked fine. However, formulas like `'3 4 +'` would work because of the internal implementation not actually caring about fixity / etc. With this patch, Formula's like this one will raise an exception. Formulaic also now returns helpful error messages to the user.

Closes #9.
Closes #10.