### PR TITLE
Improve materializer registration, output selection, and stateful transform interface.

### DIFF
--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -60,7 +60,7 @@ class Formula:
             materializer = FormulaMaterializer.for_materializer(materializer)
         if not inspect.isclass(materializer) or not issubclass(materializer, FormulaMaterializer):
             raise FormulaMaterializerInvalidError("Materializers must be subclasses of `formulaic.materializers.FormulaMaterializer`.")
-        return materializer(data, context=context or {}, **kwargs).get_model_matrix(self, ensure_full_rank=ensure_full_rank)
+        return materializer(data, context=context or {}).get_model_matrix(self, ensure_full_rank=ensure_full_rank, **kwargs)
 
     def differentiate(self, *vars, use_sympy=False):
         return Formula([

--- a/formulaic/materializers/arrow.py
+++ b/formulaic/materializers/arrow.py
@@ -5,12 +5,11 @@ from .pandas import PandasMaterializer
 
 class ArrowMaterializer(PandasMaterializer):
 
-    REGISTRY_NAME = 'arrow'
-    DEFAULT_FOR = ['pyarrow.lib.Table']
+    REGISTER_NAME = 'arrow'
+    REGISTER_INPUTS = ('pyarrow.lib.Table', )
 
     @override
-    def _init(self, sparse=False):
-        super()._init(sparse=sparse)
+    def _init(self):
         self.__data_context = LazyArrowTableProxy(self.data)
 
     @override

--- a/formulaic/materializers/transforms/basis_spline.py
+++ b/formulaic/materializers/transforms/basis_spline.py
@@ -30,7 +30,7 @@ def basis_spline(
         lower_bound: Optional[float] = None,
         upper_bound: Optional[float] = None,
         extrapolation: Union[str, SplineExtrapolation] = 'raise',
-        state: dict = None,
+        _state: dict = None,
 ):
     """
     Evaluates the B-Spline basis vectors for given inputs `x`.
@@ -94,11 +94,11 @@ def basis_spline(
     # Prepare and check arguments
     if df is not None and knots is not None:
         raise ValueError("You cannot specify both `df` and `knots`.")
-    lower_bound = numpy.min(x) if state.get('lower_bound', lower_bound) is None else lower_bound
-    upper_bound = numpy.max(x) if state.get('upper_bound', upper_bound) is None else upper_bound
+    lower_bound = numpy.min(x) if _state.get('lower_bound', lower_bound) is None else lower_bound
+    upper_bound = numpy.max(x) if _state.get('upper_bound', upper_bound) is None else upper_bound
     extrapolation = SplineExtrapolation(extrapolation)
-    state['lower_bound'] = lower_bound
-    state['upper_bound'] = upper_bound
+    _state['lower_bound'] = lower_bound
+    _state['upper_bound'] = upper_bound
 
     # Prepare data
     if extrapolation is SplineExtrapolation.RAISE and numpy.any((x < lower_bound) | (x > upper_bound)):
@@ -112,7 +112,7 @@ def basis_spline(
         x = numpy.where((x >= lower_bound) & (x <= upper_bound), x, numpy.nan)
 
     # Prepare knots
-    if 'knots' not in state:
+    if 'knots' not in _state:
         knots = knots or []
         if df:
             nknots = df - degree - (1 if include_intercept else 0)
@@ -122,9 +122,8 @@ def basis_spline(
         knots.insert(0, lower_bound)
         knots.append(upper_bound)
         knots = list(numpy.pad(knots, degree, mode='edge'))
-        state['knots'] = knots
-    knots = state['knots']
-    print(knots)
+        _state['knots'] = knots
+    knots = _state['knots']
 
     # Compute basis splines
     # The following code is equivalent to [B(i, j=degree) for in range(len(knots)-d-1)], with B(i, j) as defined below.

--- a/formulaic/materializers/transforms/encode_categorical.py
+++ b/formulaic/materializers/transforms/encode_categorical.py
@@ -11,10 +11,11 @@ from formulaic.utils.stateful_transforms import stateful_transform
 
 
 @stateful_transform
-def encode_categorical(data, metadata, state, config, reduced_rank=False, spans_intercept=True):
+def encode_categorical(data, reduced_rank=False, spans_intercept=True, output=None, _state=None, _spec=None):
     # TODO: Add support for specifying contrast matrix / etc
+    output = output or _spec.output or 'pandas'
 
-    if config.sparse:
+    if output == 'sparse':
         data = numpy.array(data)
         data = data.reshape((data.size, ))
         categories, encoded = categorical_encode_series_to_sparse_csc_matrix(data, reduced_rank=reduced_rank)
@@ -24,28 +25,28 @@ def encode_categorical(data, metadata, state, config, reduced_rank=False, spans_
         encoded = dict(pandas.get_dummies(data, drop_first=reduced_rank))
 
     # Update state
-    if 'categories' in state:
-        extra_categories = set(categories).difference(state['categories'])
+    if 'categories' in _state:
+        extra_categories = set(categories).difference(_state['categories'])
         if extra_categories:
             warnings.warn(f"Data has categories that were not seen in original dataset: {extra_categories}. This will likely skew the results of your analyses.", DataMismatchWarning)
             for category in extra_categories:
                 del encoded[category]
 
-        missing_categories = set(state['categories']).difference(categories)
+        missing_categories = set(_state['categories']).difference(categories)
         if missing_categories:
             for missing_category in missing_categories:
-                if config.sparse:
+                if output == 'sparse':
                     encoded[missing_category] = spsparse.csc_matrix((data.shape[0], 1))
                 else:
                     encoded[missing_category] = pandas.Series(numpy.zeros(data.shape[0]))
             encoded = OrderedDict(sorted(encoded.items(), key=lambda x: x[0]))
     else:
-        state['categories'] = categories
+        _state['categories'] = categories
 
     encoded.update({
         '__kind__': 'categorical',
         '__spans_intercept__': spans_intercept and not reduced_rank,
-        '__drop_field__': state['categories'][0] if spans_intercept and not reduced_rank else None,
+        '__drop_field__': _state['categories'][0] if spans_intercept and not reduced_rank else None,
         '__format__': "{name}[T.{field}]",
         '__encoded__': True,
     })

--- a/formulaic/materializers/transforms/scale.py
+++ b/formulaic/materializers/transforms/scale.py
@@ -5,36 +5,36 @@ from formulaic.utils.stateful_transforms import stateful_transform
 
 
 @stateful_transform
-def scale(data, center=True, scale=True, ddof=1, state=None):
+def scale(data, center=True, scale=True, ddof=1, _state=None):
 
     data = numpy.array(data)
 
-    if 'ddof' not in state:
-        state['ddof'] = ddof
+    if 'ddof' not in _state:
+        _state['ddof'] = ddof
     else:
-        ddof = state['ddof']
+        ddof = _state['ddof']
 
     # Handle centering
-    if 'center' not in state:
+    if 'center' not in _state:
         if isinstance(center, bool) and center:
-            state['center'] = numpy.mean(data, axis=0)
+            _state['center'] = numpy.mean(data, axis=0)
         elif not isinstance(center, bool):
-            state['center'] = numpy.array(center)
+            _state['center'] = numpy.array(center)
         else:
-            state['center'] = None
-    if state['center'] is not None:
-        data = data - state['center']
+            _state['center'] = None
+    if _state['center'] is not None:
+        data = data - _state['center']
 
     # Handle scaling
-    if 'scale' not in state:
+    if 'scale' not in _state:
         if isinstance(scale, bool) and scale:
-            state['scale'] = numpy.sqrt(numpy.sum(data ** 2, axis=0) / (data.shape[0] - ddof))
+            _state['scale'] = numpy.sqrt(numpy.sum(data ** 2, axis=0) / (data.shape[0] - ddof))
         elif not isinstance(scale, bool):
-            state['scale'] = numpy.array(scale)
+            _state['scale'] = numpy.array(scale)
         else:
-            state['scale'] = None
-    if state['scale'] is not None:
-        data = data / state['scale']
+            _state['scale'] = None
+    if _state['scale'] is not None:
+        data = data / _state['scale']
 
     return data
 
@@ -46,5 +46,5 @@ def _(data, *args, **kwargs):
 
 
 @stateful_transform
-def center(data, state=None):
-    return scale(data, scale=False, state=state)
+def center(data, _state=None):
+    return scale(data, scale=False, _state=_state)

--- a/formulaic/model_matrix.py
+++ b/formulaic/model_matrix.py
@@ -3,8 +3,13 @@ import wrapt
 
 class ModelMatrix(wrapt.ObjectProxy):
 
-    __slots__ = ('formula', 'materializer')
-
     def __init__(self, data, spec=None):
         wrapt.ObjectProxy.__init__(self, data)
-        self.model_spec = spec
+        self._self_model_spec = spec
+
+    @property
+    def model_spec(self):
+        return self._self_model_spec
+
+    def __repr__(self):
+        return self.__wrapped__.__repr__()  # pragma: no cover

--- a/formulaic/model_spec.py
+++ b/formulaic/model_spec.py
@@ -7,14 +7,15 @@ from .materializers import FormulaMaterializer, NAAction
 
 class ModelSpec:
 
-    def __init__(self, formula, ensure_full_rank=True, structure=None, materializer=None, na_action='drop', transforms=None, encoding=None):
+    def __init__(self, formula, ensure_full_rank=True, structure=None, materializer=None, na_action='drop', output=None, transform_state=None, encoder_state=None):
         self.formula = Formula.from_spec(formula)
         self.ensure_full_rank = ensure_full_rank
         self.structure = structure
         self.materializer = materializer
         self.na_action = NAAction(na_action)
-        self.transforms = transforms or {}
-        self.encoding = encoding or {}
+        self.output = output
+        self.transform_state = transform_state or {}
+        self.encoder_state = encoder_state or {}
 
     @property
     def materializer(self):
@@ -23,7 +24,7 @@ class ModelSpec:
     @materializer.setter
     def materializer(self, materializer):
         if isinstance(materializer, FormulaMaterializer) or inspect.isclass(materializer) and issubclass(materializer, FormulaMaterializer):
-            materializer = materializer.REGISTRY_NAME
+            materializer = materializer.REGISTER_NAME
         assert materializer is None or isinstance(materializer, str), materializer
         self._materializer = materializer
 
@@ -65,6 +66,6 @@ class ModelSpec:
             ensure_full_rank=self.ensure_full_rank,
             structure=self.structure,
             materializer=self.materializer,
-            transforms=self.transforms,
-            encoding=self.encoding,
+            transform_state=self.transform_state,
+            encoder_state=self.encoder_state,
         )

--- a/tests/materializers/test_arrow.py
+++ b/tests/materializers/test_arrow.py
@@ -34,10 +34,6 @@ class TestArrowMaterializer:
     def materializer(self, data):
         return ArrowMaterializer(data)
 
-    @pytest.fixture
-    def materializer_sparse(self, data):
-        return ArrowMaterializer(data, sparse=True)
-
     @pytest.mark.parametrize("formula,tests", ARROW_TESTS.items())
     def test_get_model_matrix(self, materializer, formula, tests):
         mm = materializer.get_model_matrix(formula, ensure_full_rank=True)
@@ -51,13 +47,13 @@ class TestArrowMaterializer:
         assert list(mm.columns) == tests[1]
 
     @pytest.mark.parametrize("formula,tests", ARROW_TESTS.items())
-    def test_get_model_matrix_sparse(self, materializer_sparse, formula, tests):
-        mm = materializer_sparse.get_model_matrix(formula, ensure_full_rank=True)
+    def test_get_model_matrix_sparse(self, materializer, formula, tests):
+        mm = materializer.get_model_matrix(formula, ensure_full_rank=True, output='sparse')
         assert isinstance(mm, spsparse.csc_matrix)
         assert mm.shape == (3, len(tests[0]))
         assert list(mm.model_spec.feature_names) == tests[0]
 
-        mm = materializer_sparse.get_model_matrix(formula, ensure_full_rank=False)
+        mm = materializer.get_model_matrix(formula, ensure_full_rank=False, output='sparse')
         assert isinstance(mm, spsparse.csc_matrix)
         assert mm.shape == (3, len(tests[1]))
         assert list(mm.model_spec.feature_names) == tests[1]

--- a/tests/materializers/transforms/test_encode_categorical.py
+++ b/tests/materializers/transforms/test_encode_categorical.py
@@ -4,13 +4,14 @@ import scipy.sparse as spsparse
 
 from formulaic.errors import DataMismatchWarning
 from formulaic.materializers.transforms import encode_categorical
+from formulaic.model_spec import ModelSpec
 
 
 def test_encode_categorical():
     state = {}
-    config = {'sparse': False}
+    spec = ModelSpec([], output='pandas')
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], _state=state, _spec=spec),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': True,
@@ -26,7 +27,7 @@ def test_encode_categorical():
 
     with pytest.warns(DataMismatchWarning):
         _compare_formulaic_dict(
-            encode_categorical(data=['a', 'b', 'd', 'a', 'b', 'd'], state=state, config=config),
+            encode_categorical(data=['a', 'b', 'd', 'a', 'b', 'd'], _state=state, _spec=spec),
             {
                 '__kind__': 'categorical',
                 '__spans_intercept__': True,
@@ -41,7 +42,7 @@ def test_encode_categorical():
         assert state['categories'] == ['a', 'b', 'c']
 
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config, reduced_rank=True),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], reduced_rank=True, _state=state, _spec=spec),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': False,
@@ -55,7 +56,7 @@ def test_encode_categorical():
     assert state['categories'] == ['a', 'b', 'c']
 
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config, reduced_rank=False, spans_intercept=False),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], reduced_rank=False, spans_intercept=False, _state=state, _spec=spec),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': False,
@@ -72,9 +73,9 @@ def test_encode_categorical():
 
 def test_encode_categorical_sparse():
     state = {}
-    config = {'sparse': True}
+    spec = ModelSpec([], output='sparse')
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], _state=state, _spec=spec),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': True,
@@ -89,7 +90,7 @@ def test_encode_categorical_sparse():
     assert state['categories'] == ['a', 'b', 'c']
 
     _compare_formulaic_dict(
-        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], state=state, config=config, reduced_rank=True),
+        encode_categorical(data=['a', 'b', 'c', 'a', 'b', 'c'], reduced_rank=True, _state=state, _spec=spec),
         {
             '__kind__': 'categorical',
             '__spans_intercept__': False,
@@ -104,7 +105,7 @@ def test_encode_categorical_sparse():
 
     with pytest.warns(DataMismatchWarning):
         _compare_formulaic_dict(
-            encode_categorical(data=['a', 'b', 'd', 'a', 'b', 'd'], state=state, config=config),
+            encode_categorical(data=['a', 'b', 'd', 'a', 'b', 'd'], _state=state, _spec=spec),
             {
                 '__kind__': 'categorical',
                 '__spans_intercept__': True,

--- a/tests/materializers/transforms/test_scale.py
+++ b/tests/materializers/transforms/test_scale.py
@@ -8,35 +8,35 @@ from formulaic.materializers.transforms import center, scale
 
 def test_scale():
     state = {}
-    assert numpy.allclose(scale(data=[1, 2, 3], state=state), [-1, 0, 1])
+    assert numpy.allclose(scale(data=[1, 2, 3], _state=state), [-1, 0, 1])
     assert state == {'center': 2.0, 'scale': 1.0, 'ddof': 1}
-    assert numpy.allclose(scale(data=[5, 6, 7], state=state), [3, 4, 5])
+    assert numpy.allclose(scale(data=[5, 6, 7], _state=state), [3, 4, 5])
 
     state = {}
-    assert numpy.allclose(scale(data=[1, 2, 3], center=False, state=state), [0.37796447, 0.75592895, 1.13389342])
+    assert numpy.allclose(scale(data=[1, 2, 3], center=False, _state=state), [0.37796447, 0.75592895, 1.13389342])
     assert state == {'center': None, 'scale': 2.6457513110645907, 'ddof': 1}
-    assert numpy.allclose(scale(data=[5, 6, 7], center=False, state=state), [1.88982237, 2.26778684, 2.64575131])
+    assert numpy.allclose(scale(data=[5, 6, 7], center=False, _state=state), [1.88982237, 2.26778684, 2.64575131])
 
     state = {}
-    assert numpy.allclose(scale(data=[1, 2, 3], center=False, scale=False, state=state), [1, 2, 3])
+    assert numpy.allclose(scale(data=[1, 2, 3], center=False, scale=False, _state=state), [1, 2, 3])
     assert state == {'center': None, 'scale': None, 'ddof': 1}
 
     state = {}
-    assert numpy.allclose(scale(data=[1, 2, 3], center=1, scale=False, state=state), [0, 1, 2])
+    assert numpy.allclose(scale(data=[1, 2, 3], center=1, scale=False, _state=state), [0, 1, 2])
     assert state == {'center': 1, 'scale': None, 'ddof': 1}
 
     state = {}
-    assert numpy.allclose(scale(data=[1, 2, 3], center=1, scale=2, state=state), [0, 0.5, 1])
+    assert numpy.allclose(scale(data=[1, 2, 3], center=1, scale=2, _state=state), [0, 0.5, 1])
     assert state == {'center': 1, 'scale': 2, 'ddof': 1}
 
 def test_center():
     state = {}
-    assert numpy.allclose(center(data=[1, 2, 3], state=state), [-1, 0, 1])
+    assert numpy.allclose(center(data=[1, 2, 3], _state=state), [-1, 0, 1])
     assert state == {'center': 2, 'scale': None, 'ddof': 1}
-    assert numpy.allclose(center(data=[5, 6, 7], state=state), [3, 4, 5])
+    assert numpy.allclose(center(data=[5, 6, 7], _state=state), [3, 4, 5])
 
 
 def test_center_sparse():
     state = {}
     m = spsparse.csc_matrix([1, 2, 3]).transpose()
-    assert numpy.allclose(center(data=m, state=state), [-1, 0, 1])
+    assert numpy.allclose(center(data=m, _state=state), [-1, 0, 1])

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -58,8 +58,8 @@ class TestModelSpec:
 
         model_spec.materializer = None
         m2 = model_spec.get_model_matrix(data2)
-        assert isinstance(m, pandas.DataFrame)
-        assert list(m.columns) == model_spec.feature_names
+        assert isinstance(m2, pandas.DataFrame)
+        assert list(m2.columns) == model_spec.feature_names
 
     def test_differentiate(self, model_spec, formula):
         assert model_spec.differentiate('a').formula == formula.differentiate('a')

--- a/tests/utils/test_stateful_transforms.py
+++ b/tests/utils/test_stateful_transforms.py
@@ -2,18 +2,22 @@ from formulaic.utils.stateful_transforms import stateful_eval, stateful_transfor
 
 
 @stateful_transform
-def dummy_transform(data, state, config):
-    if 'data' not in state:
-        state['data'] = data
-    return state['data']
+def dummy_transform(data, _state=None, _spec=None, _metadata=None):
+    if _metadata is not None:
+        _metadata['added'] = True
+    if 'data' not in _state:
+        _state['data'] = data
+    return _state['data']
 
 
 def test_stateful_transform():
 
     state = {}
-    assert dummy_transform(1, state=state) == 1
+    metadata = {}
+    assert dummy_transform(1, _state=state, _metadata=metadata) == 1
     assert state['data'] == 1
-    assert dummy_transform(2, state=state) == 1
+    assert metadata.get('added') is True
+    assert dummy_transform(2, _state=state) == 1
     assert dummy_transform(2) == 2
 
 


### PR DESCRIPTION
This is a breaking change to the API for users who take advantage of the `sparse=True` functionality, but is more general.

Instead of `sparse=True`, pass `output='sparse'` to the `get_model_matrix` method.