### PR TITLE
Add support for mixed effects.

### DIFF
--- a/formulaic/parser/types/__init__.py
+++ b/formulaic/parser/types/__init__.py
@@ -4,7 +4,7 @@ from .formula_parser import FormulaParser
 from .operator import Operator
 from .operator_resolver import OperatorResolver
 from .structured import Structured
-from .term import Term
+from .term import Term, TermGroup
 from .token import Token
 
 
@@ -16,5 +16,6 @@ __all__ = [
     "OperatorResolver",
     "Structured",
     "Term",
+    "TermGroup",
     "Token",
 ]

--- a/formulaic/parser/types/term.py
+++ b/formulaic/parser/types/term.py
@@ -52,3 +52,23 @@ class Term:
 
     def __repr__(self):
         return ":".join(self._factor_exprs)
+
+
+class TermGroup(Term):
+    """
+    Represents a group randomized term a formula.
+
+    Attributes:
+        term:
+        group:
+        joiner:
+    """
+
+    def __init__(self, term, group, joiner="|"):
+        self.term = term
+        self.group = group
+        self.joiner = joiner
+        super().__init__(factors=[*term.factors, *group.factors], preserve_rank=True)
+
+    def __repr__(self):
+        return repr(self.term) + self.joiner + repr(self.group)

--- a/formulaic/parser/types/term.py
+++ b/formulaic/parser/types/term.py
@@ -13,10 +13,14 @@ class Term:
 
     Attributes:
         factors: The set of factors to be multipled to form the term.
+        preserve_rank: Whether to preserve the term structure even when
+            `ensure_full_rank` is specified. Other terms without this set may
+            still be affected by the presence of this term.
     """
 
-    def __init__(self, factors: Iterable["Factor"]):
+    def __init__(self, factors: Iterable["Factor"], preserve_rank: bool = False):
         self.factors = tuple(sorted(set(factors)))
+        self.preserve_rank = preserve_rank
         self._factor_exprs = tuple(factor.expr for factor in self.factors)
         self._hash = hash(repr(self))
 


### PR DESCRIPTION
Hi @tomicapretto,

I stumbled across your cool [formulae](https://github.com/bambinos/formulae) project recently, and it piqued my interest. One of the primary goals of `formulaic` was to be easily extensible to support new use-cases, much like that of `formulae`. As such, I wanted to try my hand at a quick extension to Formulaic that would support your use-case, while keeping it general so that others can plug into it also. I don't necessarily want you to throw away your excellent work on Formulae, nor is this PR immediately ready for merging... but I'd love to get your take on this. Perhaps there is opportunity for synergy.

With this PR, you can do:
```
import pandas
import numpy as np
n = 1000000
df = pandas.DataFrame(
    dict(
        y=np.random.normal(size=n),
        x1=np.random.normal(size=n),
        x2=np.random.normal(size=n),
        m=np.random.choice(list("abc"), size=n),
        n=np.random.choice(list("abc"), size=n),
        e=np.random.normal(size=n),
    )
)

from formulaic import model_matrix

mm = model_matrix("x1 + (x2|m) + (x1||n)", df)
mm

>         Intercept        x1  m[T.a]:x2  m[T.b]:x2  m[T.c]:x2  n[T.b]:x1  \
> 0             1.0 -0.638156  -0.000000  -0.465160  -0.000000  -0.000000   
> 1             1.0 -1.198965   0.000000   0.375026   0.000000  -1.198965   
> 2             1.0 -0.616979  -0.000000  -0.000000  -0.146729  -0.000000   
> 3             1.0 -0.579646  -0.000000  -0.702864  -0.000000  -0.000000   
> 4             1.0  1.837394   0.455112   0.000000   0.000000   1.837394   
> ...           ...       ...        ...        ...        ...        ...   
> 999995        1.0 -0.925889   0.867100   0.000000   0.000000  -0.925889   
> 999996        1.0  1.256724  -0.000000  -1.150915  -0.000000   1.256724   
> 999997        1.0  0.456776   0.352201   0.000000   0.000000   0.000000   
> 999998        1.0 -0.610327   0.384456   0.000000   0.000000  -0.000000   
> 999999        1.0 -0.840609   0.000000   0.191039   0.000000  -0.000000   
> 
>         n[T.c]:x1  
> 0       -0.000000  
> 1       -0.000000  
> 2       -0.000000  
> 3       -0.000000  
> 4        0.000000  
> ...           ...  
> 999995  -0.000000  
> 999996   0.000000  
> 999997   0.456776  
> 999998  -0.610327  
> 999999  -0.000000  
>
>[1000000 rows x 7 columns]

mm.subset() # Common/fixed effects
>         Intercept        x1
> 0             1.0 -0.638156
> 1             1.0 -1.198965
> 2             1.0 -0.616979
> 3             1.0 -0.579646
> 4             1.0  1.837394
> ...           ...       ...
> 999995        1.0 -0.925889
> 999996        1.0  1.256724
> 999997        1.0  0.456776
> 999998        1.0 -0.610327
> 999999        1.0 -0.840609
> 
> [1000000 rows x 2 columns]

mm.subset(['group']) # Group/Random effects
>         m[T.a]:x2  m[T.b]:x2  m[T.c]:x2
> 0       -0.000000  -0.465160  -0.000000
> 1        0.000000   0.375026   0.000000
> 2       -0.000000  -0.000000  -0.146729
> 3       -0.000000  -0.702864  -0.000000
> 4        0.455112   0.000000   0.000000
> ...           ...        ...        ...
> 999995   0.867100   0.000000   0.000000
> 999996  -0.000000  -1.150915  -0.000000
> 999997   0.352201   0.000000   0.000000
> 999998   0.384456   0.000000   0.000000
> 999999   0.000000   0.191039   0.000000
> 
> [1000000 rows x 3 columns]

mm.subset(['group_independent'])  # Group/Random effects assuming independence (missing one column due to enforcing of structural linear independence; can be disabled)
>         n[T.b]:x1  n[T.c]:x1
> 0       -0.000000  -0.000000
> 1       -1.198965  -0.000000
> 2       -0.000000  -0.000000
> 3       -0.000000  -0.000000
> 4        1.837394   0.000000
> ...           ...        ...
> 999995  -0.925889  -0.000000
> 999996   1.256724   0.000000
> 999997   0.000000   0.456776
> 999998  -0.000000  -0.610327
> 999999  -0.000000  -0.000000
> 
> [1000000 rows x 2 columns]

mm.subset(['group', 'group_independent'], exact=False)  # All Group/Random effects
>         m[T.a]:x2  m[T.b]:x2  m[T.c]:x2  n[T.b]:x1  n[T.c]:x1
> 0       -0.000000  -0.465160  -0.000000  -0.000000  -0.000000
> 1        0.000000   0.375026   0.000000  -1.198965  -0.000000
> 2       -0.000000  -0.000000  -0.146729  -0.000000  -0.000000
> 3       -0.000000  -0.702864  -0.000000  -0.000000  -0.000000
> 4        0.455112   0.000000   0.000000   1.837394   0.000000
> ...           ...        ...        ...        ...        ...
> 999995   0.867100   0.000000   0.000000  -0.925889  -0.000000
> 999996  -0.000000  -1.150915  -0.000000   1.256724   0.000000
> 999997   0.352201   0.000000   0.000000   0.000000   0.456776
> 999998   0.384456   0.000000   0.000000  -0.000000  -0.610327
> 999999   0.000000   0.191039   0.000000  -0.000000  -0.000000
> 
> [1000000 rows x 5 columns]
```

For something like this to be tenable for your use-cases, what further additions would be desirable? One thing I think could definitely be added pretty easily is aliasing of the terms to match the "<variable>|<group>" notation.