### PR TITLE
Draft: Add support for storing modelling metadata from stateful transforms, such as `offset`.

### DIFF
--- a/formulaic/materializers/pandas.py
+++ b/formulaic/materializers/pandas.py
@@ -45,14 +45,14 @@ class PandasMaterializer(FormulaMaterializer):
             raise ValueError(f"Do not know how to interpret `na_action` = {repr(na_action)}.")  # pragma: no cover; this is currently impossible to reach
 
     @override
-    def _encode_constant(self, value, metadata, encoder_state, spec, drop_rows):
+    def _encode_constant(self, value, encoder_state, spec, drop_rows):
         if spec.output == 'sparse':
             return spsparse.csc_matrix(numpy.array([value] * self.nrows).reshape((self.nrows - len(drop_rows), 1)))
         series = value * numpy.ones(self.nrows - len(drop_rows))
         return series
 
     @override
-    def _encode_numerical(self, values, metadata, encoder_state, spec, drop_rows):
+    def _encode_numerical(self, values, encoder_state, spec, drop_rows):
         if drop_rows:
             values = values.drop(index=values.index[drop_rows])
         if spec.output == 'sparse':
@@ -60,14 +60,14 @@ class PandasMaterializer(FormulaMaterializer):
         return values
 
     @override
-    def _encode_categorical(self, values, metadata, encoder_state, spec, drop_rows, reduced_rank=False):
+    def _encode_categorical(self, values, encoder_state, spec, drop_rows, reduced_rank=False):
         # Even though we could reduce rank here, we do not, so that the same
         # encoding can be cached for both reduced and unreduced rank. The
         # rank will be reduced in the _encode_evaled_factor method.
         from .transforms import encode_categorical
         if drop_rows:
             values = values.drop(index=values.index[drop_rows])
-        return encode_categorical(values, reduced_rank=False, _metadata=metadata, _state=encoder_state, _spec=spec)
+        return encode_categorical(values, reduced_rank=False, _state=encoder_state, _spec=spec)
 
     @override
     def _get_columns_for_term(self, factors, spec, scale=1):

--- a/formulaic/materializers/types/evaluated_factor.py
+++ b/formulaic/materializers/types/evaluated_factor.py
@@ -23,10 +23,6 @@ class EvaluatedFactor:
     def expr(self):
         return self.factor.expr
 
-    @property
-    def metadata(self):
-        return self.factor.metadata
-
     def __repr__(self):
         return repr(self.factor)
 

--- a/formulaic/model_matrix.py
+++ b/formulaic/model_matrix.py
@@ -3,13 +3,18 @@ import wrapt
 
 class ModelMatrix(wrapt.ObjectProxy):
 
-    def __init__(self, data, spec=None):
+    def __init__(self, data, spec=None, metadata=None):
         wrapt.ObjectProxy.__init__(self, data)
         self._self_model_spec = spec
+        self._self_metadata = metadata or {}
 
     @property
     def model_spec(self):
         return self._self_model_spec
+
+    @property
+    def metadata(self):
+        return self._self_metadata
 
     def __repr__(self):
         return self.__wrapped__.__repr__()  # pragma: no cover

--- a/formulaic/parser/types/factor.py
+++ b/formulaic/parser/types/factor.py
@@ -17,13 +17,12 @@ class Factor:
         NUMERICAL = 'numerical'
         CATEGORICAL = 'categorical'
 
-    __slots__ = ('expr', '_eval_method', '_kind', 'metadata')
+    __slots__ = ('expr', '_eval_method', '_kind')
 
-    def __init__(self, expr='', *, eval_method=None, kind=None, metadata=None):
+    def __init__(self, expr='', *, eval_method=None, kind=None):
         self.expr = expr
         self.eval_method = eval_method
         self.kind = kind
-        self.metadata = metadata or {}
 
     @property
     def eval_method(self):

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -104,24 +104,24 @@ class TestPandasMaterializer:
 
     def test_factor_evaluation_edge_cases(self, materializer):
         # Test that categorical kinds are set if type would otherwise be numerical
-        ev_factor = materializer._evaluate_factor(Factor('a', eval_method='lookup', kind='categorical'), ModelSpec([]), drop_rows=set())
+        ev_factor = materializer._evaluate_factor(Factor('a', eval_method='lookup', kind='categorical'), ModelSpec([]), drop_rows=set(), metadata=None)
         assert ev_factor.kind.value == 'categorical'
 
         # Test that other kind mismatches result in an exception
         materializer.factor_cache = {}
         with pytest.raises(FactorEncodingError):
-            materializer._evaluate_factor(Factor('A', eval_method='lookup', kind='numerical'), ModelSpec([]), drop_rows=[])
+            materializer._evaluate_factor(Factor('A', eval_method='lookup', kind='numerical'), ModelSpec([]), drop_rows=[], metadata=None)
 
         # Test that if an encoding has already been determined, that an exception is raised
         # if the new encoding does not match
         materializer.factor_cache = {}
         with pytest.raises(FactorEncodingError):
-            materializer._evaluate_factor(Factor('a', eval_method='lookup', kind='numerical'), ModelSpec([], encoder_state={'a': ('categorical', {})}), drop_rows=[])
+            materializer._evaluate_factor(Factor('a', eval_method='lookup', kind='numerical'), ModelSpec([], encoder_state={'a': ('categorical', {})}), drop_rows=[], metadata=None)
 
         # Test that invalid (kind == UNKNOWN) factors raise errors
         materializer.factor_cache = {}
         with pytest.raises(FactorEvaluationError):
-            assert materializer._evaluate_factor(Factor('a'), ModelSpec([]), drop_rows=set())
+            assert materializer._evaluate_factor(Factor('a'), ModelSpec([]), drop_rows=set(), metadata=None)
 
     def test_categorical_dict_detection(self, materializer):
         assert materializer._is_categorical({'__kind__': 'categorical'})

--- a/tests/utils/test_stateful_transforms.py
+++ b/tests/utils/test_stateful_transforms.py
@@ -6,9 +6,7 @@ from formulaic.utils.stateful_transforms import stateful_eval, stateful_transfor
 
 
 @stateful_transform
-def dummy_transform(data, _state=None, _spec=None, _metadata=None):
-    if _metadata is not None:
-        _metadata['added'] = True
+def dummy_transform(data, _state=None, _spec=None):
     if 'data' not in _state:
         _state['data'] = data
     return _state['data']
@@ -17,10 +15,8 @@ def dummy_transform(data, _state=None, _spec=None, _metadata=None):
 def test_stateful_transform():
 
     state = {}
-    metadata = {}
-    assert dummy_transform(1, _state=state, _metadata=metadata) == 1
+    assert dummy_transform(1, _state=state) == 1
     assert state['data'] == 1
-    assert metadata.get('added') is True
     assert dummy_transform(2, _state=state) == 1
     assert dummy_transform(2) == 2
 
@@ -28,9 +24,9 @@ def test_stateful_transform():
 def test_stateful_eval():
     state = {}
 
-    assert stateful_eval("dummy_transform(data)", {'dummy_transform': dummy_transform, 'data': 1}, None, state, None) == 1
+    assert stateful_eval("dummy_transform(data)", {'dummy_transform': dummy_transform, 'data': 1}, state, None, None) == 1
     assert state == {"dummy_transform(data)": {'data': 1}}
-    assert stateful_eval("dummy_transform(data)", {'dummy_transform': dummy_transform, 'data': 2}, None, state, None) == 1
+    assert stateful_eval("dummy_transform(data)", {'dummy_transform': dummy_transform, 'data': 2}, state, None, None) == 1
 
 
 def test_stateful_eval_variable_name_sanitization():
@@ -40,12 +36,12 @@ def test_stateful_eval_variable_name_sanitization():
 def test_stateful_eval_distribution():
     state = {}
 
-    assert stateful_eval("dummy_transform(data)", {'dummy_transform': dummy_transform, 'data': {'__property__': 'value', 'a': 1, 'b': 2}}, None, state, None) == {'__property__': 'value', 'a': 1, 'b': 2}
+    assert stateful_eval("dummy_transform(data)", {'dummy_transform': dummy_transform, 'data': {'__property__': 'value', 'a': 1, 'b': 2}}, state, None, None) == {'__property__': 'value', 'a': 1, 'b': 2}
     assert state == {"dummy_transform(data)": {'a': {'data': 1}, 'b': {'data': 2}}}
-    assert stateful_eval("dummy_transform(data)", {'dummy_transform': dummy_transform, 'data': {'__property__': 'value2', 'a': 3, 'b': 4}}, None, state, None) == {'__property__': 'value2', 'a': 1, 'b': 2}
+    assert stateful_eval("dummy_transform(data)", {'dummy_transform': dummy_transform, 'data': {'__property__': 'value2', 'a': 3, 'b': 4}}, state, None, None) == {'__property__': 'value2', 'a': 1, 'b': 2}
 
 def test_stateful_eval_func_attr():
-    assert stateful_eval("numpy.exp(0)", {'numpy': numpy}, None, {}, None) == 1.0
+    assert stateful_eval("numpy.exp(0)", {'numpy': numpy}, {}, None, None) == 1.0
 
     with pytest.raises(NameError):
-        assert stateful_eval("non_existent.me_too(0)", {}, None, {}, None)
+        assert stateful_eval("non_existent.me_too(0)", {}, {}, None, None)


### PR DESCRIPTION
This (draft) PR adds support for outputting of modelling metadata from "stateful transforms", which can be used to store (for example) modelling instructions from the formula itself (such as offsets to be used during modelling). These are distinct from `ModelSpec` in that they live alongside (and augment) the model matrix rather than being persisted as a description of the materialisation process. Example:

```
import pandas
import numpy as np
n = 1000
df = pandas.DataFrame(
    dict(
        y=np.random.normal(size=n),
        x1=np.random.normal(size=n),
        x2=np.random.normal(size=n),
        m=np.random.choice(list("abc"), size=n),
        n=np.random.choice(list("abc"), size=n),
        e=np.random.normal(size=n),
    )
)

from formulaic import model_matrix
from formulaic.utils.stateful_transforms import stateful_transform

@stateful_transform
def offset(x, _state=None, _metadata=None):
    _metadata['offset'] = _metadata.get('offset', 0) + x
    return {}

mm = model_matrix("x1 + offset(x2)", df)
mm
>      Intercept        x1
> 0          1.0  0.402157
> 1          1.0  0.159565
> 2          1.0 -0.597806
> 3          1.0 -0.469659
> 4          1.0 -0.090165
> ..         ...       ...
> 995        1.0 -2.376424
> 996        1.0  0.903574
> 997        1.0  0.266223
> 998        1.0 -0.418331
> 999        1.0 -1.261332
> 
> [1000 rows x 2 columns]

mm.metadata['offset']
0     -0.607345
1     -0.088413
2     -0.599182
3     -1.730541
4     -0.110609
         ...   
995    0.524394
996    0.063271
997    1.693313
998   -0.534796
999   -0.892107
Name: x2, Length: 1000, dtype: float64