### PR TITLE
Fix enforcement of category orders when they are re-ordered in the data.

### DIFF
--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -5,7 +5,7 @@ import itertools
 import operator
 from abc import abstractmethod
 from collections import defaultdict, OrderedDict
-from typing import Any, Dict, Iterable, Set, TYPE_CHECKING
+from typing import Any, Dict, Generator, List, Iterable, Set, Tuple, TYPE_CHECKING
 
 from interface_meta import InterfaceMeta, inherit_docs
 
@@ -20,7 +20,7 @@ from formulaic.model_matrix import ModelMatrix
 from formulaic.utils.layered_mapping import LayeredMapping
 from formulaic.utils.stateful_transforms import stateful_eval
 
-from formulaic.parser.types import Factor
+from formulaic.parser.types import Factor, Term
 from formulaic.transforms import TRANSFORMS
 
 from .types import EvaluatedFactor, FactorValues, ScopedFactor, ScopedTerm
@@ -560,7 +560,12 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
 
     # Methods related to ModelMatrix output
 
-    def _enforce_structure(self, cols, spec, drop_rows):
+    def _enforce_structure(
+        self,
+        cols: List[Tuple[Term, List[ScopedTerm], Dict[str, Any]]],
+        spec,
+        drop_rows: set,
+    ) -> Generator[Tuple[Term, List[ScopedTerm], Dict[str, Any]]]:
         # TODO: Verify that imputation strategies are intuitive and make sense.
         assert len(cols) == len(spec.structure)
         for i in range(len(cols)):
@@ -580,15 +585,12 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
                         f"Term `{cols[i][0]}` has generated insufficient columns compared to specification: generated {list(scoped_cols)}, expecting {target_cols}."
                     )
                 scoped_cols = {name: col for name in target_cols}
-            elif (
-                len(scoped_cols) == len(target_cols)
-                and list(scoped_cols) != target_cols
-            ):
+            elif set(scoped_cols) != set(target_cols):
                 raise FactorEncodingError(
                     f"Term `{cols[i][0]}` has generated columns that are inconsistent with specification: generated {list(scoped_cols)}, expecting {target_cols}."
                 )
 
-            yield cols[i][0], cols[i][1], scoped_cols
+            yield cols[i][0], cols[i][1], {col: scoped_cols[col] for col in target_cols}
 
     def _get_columns_for_term(self, factors, spec, scale=1):
         """

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -311,3 +311,34 @@ class TestPandasMaterializer:
         mm = PandasMaterializer(data).get_model_matrix("1 + a + A")
         assert list(mm.index) == [0, 2, 4, 8, 10]
         assert not numpy.any(pandas.isnull(mm))
+
+    def test_category_reordering(self):
+        data = pandas.DataFrame({"A": ["a", "b", "c"]})
+        data2 = pandas.DataFrame({"A": ["c", "b", "a"]})
+        data3 = pandas.DataFrame(
+            {"A": pandas.Categorical(["c", "b", "a"], categories=["c", "b", "a"])}
+        )
+
+        m = PandasMaterializer(data).get_model_matrix("A + 0", ensure_full_rank=False)
+        assert list(m.columns) == ["A[T.a]", "A[T.b]", "A[T.c]"]
+        assert list(m.model_spec.get_model_matrix(data3).columns) == [
+            "A[T.a]",
+            "A[T.b]",
+            "A[T.c]",
+        ]
+
+        m2 = PandasMaterializer(data2).get_model_matrix("A + 0", ensure_full_rank=False)
+        assert list(m2.columns) == ["A[T.a]", "A[T.b]", "A[T.c]"]
+        assert list(m2.model_spec.get_model_matrix(data3).columns) == [
+            "A[T.a]",
+            "A[T.b]",
+            "A[T.c]",
+        ]
+
+        m3 = PandasMaterializer(data3).get_model_matrix("A + 0", ensure_full_rank=False)
+        assert list(m3.columns) == ["A[T.c]", "A[T.b]", "A[T.a]"]
+        assert list(m3.model_spec.get_model_matrix(data).columns) == [
+            "A[T.c]",
+            "A[T.b]",
+            "A[T.a]",
+        ]


### PR DESCRIPTION
Fixes #39.

Thanks again @rafaelab23 for reporting this. It will be shipped as part of formulaic 0.3.0 sometime soon!

(New PR since CI didn't work against previous branch with a slash in the name).