### PR TITLE
BUG: Avoid importing numpy.typing if not needed

### DIFF
--- a/formulaic/transforms/poly.py
+++ b/formulaic/transforms/poly.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import numpy
+
 from formulaic.materializers.types import FactorValues
 from formulaic.utils.stateful_transforms import stateful_transform
 
-import numpy
-
 try:
     import numpy.typing
-except ImportError:
+except ImportError as e:
     if TYPE_CHECKING:
-        raise RuntimeError("Recent NumPy is required when type checking")
+        raise RuntimeError("Numpy >=1.20 is required for type-checking.") from e
 
 
 @stateful_transform

--- a/formulaic/transforms/poly.py
+++ b/formulaic/transforms/poly.py
@@ -1,8 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from formulaic.materializers.types import FactorValues
 from formulaic.utils.stateful_transforms import stateful_transform
 
 import numpy
-import numpy.typing
+
+try:
+    import numpy.typing
+except ImportError:
+    if TYPE_CHECKING:
+        raise RuntimeError("Recent NumPy is required when type checking")
 
 
 @stateful_transform


### PR DESCRIPTION
Allow for numpy typing to be deferred except when type checking

closes #66 