### PR TITLE
Add support for linear constraints.

### DIFF
--- a/formulaic/model_spec.py
+++ b/formulaic/model_spec.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 import inspect
 
+from formulaic.utils.constraints import LinearConstraints
+
 from .formula import Formula
 from .materializers import FormulaMaterializer, NAAction
 
@@ -65,6 +67,9 @@ class ModelSpec:
         else:
             materializer = FormulaMaterializer.for_materializer(self.materializer)
         return materializer(data, **kwargs).get_model_matrix(self)
+
+    def get_linear_constraints(self, spec):
+        return LinearConstraints.from_spec(spec, variable_names=self.feature_names)
 
     def differentiate(self, *vars, use_sympy=False):
         return ModelSpec(

--- a/formulaic/utils/constraints.py
+++ b/formulaic/utils/constraints.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+import numpy
+
+import ast
+import functools
+import itertools
+from numbers import Number
+from typing import Dict, Iterable, Optional, Sequence, Tuple, Union
+
+from formulaic.parser.algos.tokenize import tokenize
+from formulaic.parser.algos.tokens_to_ast import tokens_to_ast
+from formulaic.parser.types import (
+    ASTNode,
+    Factor,
+    OperatorResolver,
+    Operator,
+    Term,
+    Token,
+)
+from formulaic.parser.utils import exc_for_token
+
+
+ConstraintSpec = Union[
+    str,
+    Dict[str, Number],
+    Tuple["numpy.typing.ArrayLike", "numpy.typing.ArrayLike"],
+    "numpy.typing.ArrayLike",
+]
+
+
+class LinearConstraints:
+    """
+    Represents linear constraints of form $Ax = b$, where $A$ is a matrix of
+    coefficients for the features in $x$, and $b$ is a vector of constant
+    values.
+
+    Instances of this class are typically constructed via
+    `ModelSpec.get_linear_constraints(...)` but can also be constructed
+    directly for use in other contexts.
+
+    Attributes:
+        constraint_matrix: The matrix of coefficients on the features ($A$ from
+            above). Each row is one constraint.
+        constraint_values: The vector of constant values ($b$ from above).
+        variable_names: The ordered names of the variables represented by $x$;
+            typically the column names of a `ModelMatrix` instance.
+    """
+
+    @classmethod
+    def from_spec(
+        cls, spec: ConstraintSpec, variable_names: Sequence[str] = None
+    ) -> LinearConstraints:
+        """
+        Construct a `LinearConstraints` instance from a specification.
+
+        Args:
+            spec: The specification from which to derive the constraints. Can be
+                a:
+                    * str: In which case it is interpreted as a constraints
+                        formula (e.g. "x + 2 * y = 3, z + y - x / 10"). All
+                        variables used must be present in `variable_names`.
+                    * Dict[str, Number]: In which case each key is treated as
+                        formula, and each value as the constraint (e.g. {"x":19}
+                        , {"a + b": 0}).
+                    * Tuple: a two-tuple describing the constraint matrix and
+                        values respectively.
+                    * numpy.ndarray: a constraint matrix (with all values
+                        assumed to be zero).
+            variable_names: The ordered names of the variables represented by
+                $x$; typically the column names of a `ModelMatrix` instance.
+        """
+        if isinstance(spec, LinearConstraints):
+            return spec
+        if isinstance(spec, str):
+            matrix, values = LinearConstraintParser(
+                variable_names=variable_names
+            ).get_matrix(spec)
+            return cls(matrix, values, variable_names)
+        if isinstance(spec, dict):
+            matrices, constants = [], []
+            for key, constant in spec.items():
+                matrix, values = LinearConstraintParser(
+                    variable_names=variable_names
+                ).get_matrix(key)
+                matrices.append(matrix)
+                constants.append(values + numpy.array(constant))
+            return cls(
+                numpy.vstack(matrices),
+                numpy.hstack(constants),
+                variable_names=variable_names,
+            )
+        if isinstance(spec, tuple) and len(spec) == 2:
+            return cls(*spec, variable_names=variable_names)
+        return cls(spec, 0, variable_names=variable_names)
+
+    def __init__(
+        self, constraint_matrix, constraint_values, variable_names: Sequence[str] = None
+    ):
+        """
+        Attributes:
+            constraint_matrix: The matrix of coefficients on the features ($A$ from
+                above). Each row is one constraint.
+            constraint_values: The vector of constant values ($b$ from above).
+            variable_names: The ordered names of the variables represented by $x$;
+                typically the column names of a `ModelMatrix` instance.
+        """
+        constraint_matrix = numpy.array(constraint_matrix)
+        constraint_values = numpy.array(constraint_values)
+
+        # Prepare incoming values
+        if len(constraint_matrix.shape) == 1:
+            constraint_matrix = constraint_matrix.reshape(1, *constraint_matrix.shape)
+        if len(constraint_values.shape) == 0:
+            constraint_values = constraint_values * numpy.ones(
+                constraint_matrix.shape[0]
+            )
+        variable_names = variable_names or [
+            f"x{i}" for i in range(constraint_matrix.shape[1])
+        ]
+
+        # Validate incoming values
+        if len(constraint_matrix.shape) != 2:
+            raise ValueError("`constraint_matrix` must be a 2D array.")
+        if len(constraint_values.shape) != 1:
+            raise ValueError("`constraint_values` must be a 1D array.")
+        if constraint_values.shape[0] != constraint_matrix.shape[0]:
+            raise ValueError(
+                "Number of rows in constraint matrix does not equal the number of values in the values array."
+            )
+        if len(variable_names) != constraint_matrix.shape[1]:
+            raise ValueError(
+                "Number of column names does not match the number of columns in the linear constraint matrix."
+            )
+
+        self.constraint_matrix = constraint_matrix
+        self.constraint_values = constraint_values
+        self.variable_names = variable_names or [
+            f"x{i}" for i in range(len(constraint_matrix))
+        ]
+
+    def __str__(self):
+        out = []
+        for i in range(self.constraint_matrix.shape[0]):
+            out_one = []
+            for nonzero_col in numpy.where(self.constraint_matrix[i, :])[0]:
+                out_one.append(
+                    f"{self.constraint_matrix[i, nonzero_col]} * {self.variable_names[nonzero_col]}"
+                )
+            out.append(" + ".join(out_one) + f" = {self.constraint_values[i]}")
+        return "\n".join(out)
+
+    def show(self):
+        """
+        Pretty-print the constraints.
+        """
+        print(str(self))
+
+    @property
+    def n_constraints(self):
+        """
+        The number of constraints represented by this `LinearConstraints`
+        instance.
+        """
+        return self.constraint_matrix.shape[0]
+
+    def __repr__(self):
+        return f"<LinearConstraints: {self.n_constraints} constraints>"
+
+
+class LinearConstraintParser:
+    """
+    A linear constraint parser.
+
+    While this parser re-uses parts of the parser stack under `FormulaParser`,
+    it interprets formulas using conventional algebra (rather than Wilkinson
+    formulas).
+
+    Attributes:
+        variable_names: The ordered names of the variables for which constraints
+            are being prepared. All variables used in the formula being parsed
+            must be present in this sequence.
+        operator_resolver: The operator resolver instance to use. If not
+            provided, `ConstraintOperatorResolver` is used.
+    """
+
+    def __init__(
+        self,
+        variable_names: Sequence[str],
+        operator_resolver: Optional[OperatorResolver] = None,
+    ):
+        self.variable_names = variable_names
+        self.operator_resolver = operator_resolver or ConstraintOperatorResolver()
+
+    def get_tokens(self, formula: str) -> Iterable[ConstraintToken]:
+        """
+        Tokenize a constraint formula.
+
+        Args:
+            formula: The constraint formula to tokenize.
+        """
+        return [ConstraintToken.for_token(token) for token in tokenize(formula)]
+
+    def get_ast(self, formula: str) -> ASTNode:
+        """
+        Assemble an abstract syntax tree for the nominated `formula` string.
+
+        Args:
+            formula: The constraint formula for which an AST should be
+                generated.
+        """
+        return tokens_to_ast(
+            self.get_tokens(formula),
+            operator_resolver=self.operator_resolver,
+        )
+
+    def get_terms(self, formula: str) -> Union[Sequence[Term], Tuple[Sequence[Term]]]:
+        """
+        Build the `Term` instances for a constraint formula string.
+
+        Args:
+            formula: The constraint formula for which to build terms.
+        """
+        ast = self.get_ast(formula)
+        if not ast:
+            return None
+        return ast.to_terms()
+
+    def get_matrix(
+        self, formula: str
+    ) -> Tuple["numpy.typing.ArrayLike", "numpy.typing.ArrayLike"]:
+        """
+        Build the constraint matrix and constraint values vector associated with
+        the parsed string.
+
+        Args:
+            formula: The constraint formula for which to build the constraint
+                matrix and values vector.
+
+        Returns:
+            A tuple of the contraint matrix and constraint values respectively.
+        """
+        constraints = self.get_terms(formula)
+        if not constraints:
+            return numpy.empty((0, len(self.variable_names))), numpy.array([])
+
+        if not isinstance(constraints, tuple):
+            constraints = (constraints,)
+
+        col_vectors = {
+            col: vec
+            for col, vec in zip(
+                self.variable_names, numpy.eye(len(self.variable_names))
+            )
+        }
+
+        matrix = []
+        constants = []
+
+        for constraint in constraints:
+            vector = numpy.zeros(len(self.variable_names))
+            constant = 0
+            for term in constraint:
+                if term.factor == 1:
+                    constant += term.scale
+                else:
+                    vector += term.scale * col_vectors[term.factor.expr]
+            matrix.append(vector)
+            constants.append(-constant)
+
+        return numpy.array(matrix), numpy.array(constants)
+
+
+class ConstraintToken(Token):
+    """
+    An enriched `Token` subclass that overrides `.to_terms()` to return
+    a set of `ScaledFactor`s rather than `Terms`s.
+    """
+
+    @classmethod
+    def for_token(cls, token: Token):
+        return cls(
+            **{
+                attr: getattr(token, attr)
+                for attr in ("token", "kind", "source", "source_start", "source_end")
+            }
+        )
+
+    def to_terms(self):
+        if self.kind is Token.Kind.VALUE:
+            factor = ast.literal_eval(self.token)
+            if isinstance(factor, Number):
+                return {ScaledFactor(1, scale=factor)}
+            raise exc_for_token(
+                self,
+                message="Only numeric literal values are permitted in constraint formulae.",
+            )
+        return {ScaledFactor(self.to_factor())}
+
+
+class ScaledFactor:
+    """
+    A wrapper around a `Factor` instance that provides an additional "scale"
+    attribute to allow storing information about the scalar coefficient of each
+    `Factor`.
+
+    Attributes:
+        factor: The wrapped `Factor` instance.
+        scale: The scalar value to be used as the coefficient of this factor.
+    """
+
+    def __init__(self, factor: Factor, *, scale: Number = 1):
+        self.factor = factor
+        self.scale = scale
+
+    def __add__(self, other):
+        if isinstance(other, ScaledFactor):
+            return ScaledFactor(self.factor, scale=self.scale + other.scale)
+        return NotImplemented  # pragma: no cover
+
+    def __sub__(self, other):
+        if isinstance(other, ScaledFactor):
+            return ScaledFactor(self.factor, scale=self.scale - other.scale)
+        return NotImplemented  # pragma: no cover
+
+    def __neg__(self):
+        return ScaledFactor(self.factor, scale=-self.scale)
+
+    def __hash__(self):
+        return hash(self.factor)
+
+    def __eq__(self, other):
+        if isinstance(other, ScaledFactor):
+            return self.factor == other.factor
+        return NotImplemented  # pragma: no cover
+
+    def __repr__(self):
+        return f"{self.scale}*{self.factor}"  # pragma: no cover
+
+
+class ConstraintOperatorResolver(OperatorResolver):
+    """
+    The default constraint `OperatorResolver` implementation.
+
+    These operators describe a regular algebra rather than a Wikinson formula
+    one.
+    """
+
+    @property
+    def operators(self):
+        def add_terms(terms_left, terms_right):
+
+            terms_left = {term: term for term in terms_left}
+            terms_right = {term: term for term in terms_right}
+
+            added = set()
+
+            for term in terms_left:
+                if term in terms_right:
+                    term = term + terms_right[term]
+                added.add(term)
+            added.update({term for term in terms_right if term not in added})
+
+            return added
+
+        def sub_terms(terms_left, terms_right):
+
+            terms_left = {term: term for term in terms_left}
+            terms_right = {term: term for term in terms_right}
+
+            added = set()
+
+            for term in terms_left:
+                if term in terms_right:
+                    term = term - terms_right[term]
+                added.add(term)
+            added.update(
+                negate_terms({term for term in terms_right if term not in added})
+            )
+
+            return added
+
+        def negate_terms(terms):
+            return {-term for term in terms}
+
+        def mul_terms(terms_left, terms_right):
+            terms_left = {term: term for term in terms_left}
+            terms_right = {term: term for term in terms_right}
+
+            terms = set()
+
+            for term_left, term_right in itertools.product(terms_left, terms_right):
+                terms = add_terms(terms, {mul_term(term_left, term_right)})
+
+            return terms
+
+        def mul_term(term_left, term_right):
+            if term_left.factor == 1:
+                return ScaledFactor(
+                    term_right.factor, scale=term_left.scale * term_right.scale
+                )
+            if term_right.factor == 1:
+                return ScaledFactor(
+                    term_left.factor, scale=term_left.scale * term_right.scale
+                )
+            raise RuntimeError(
+                "Only one non-scalar factor can be involved in a linear constraint multiplication."
+            )
+
+        def div_terms(terms_left, terms_right):
+            terms_left = {term: term for term in terms_left}
+            terms_right = {term: term for term in terms_right}
+
+            terms = set()
+
+            for term_left, term_right in itertools.product(terms_left, terms_right):
+                terms = add_terms(terms, {div_term(term_left, term_right)})
+
+            return terms
+
+        def div_term(term_left, term_right):
+            if term_right.factor == 1:
+                return ScaledFactor(
+                    term_left.factor, scale=term_left.scale / term_right.scale
+                )
+            raise RuntimeError(
+                "The right-hand operand must be a scalar in linear constraint division operations."
+            )
+
+        return [
+            Operator(
+                ",",
+                arity=2,
+                precedence=-200,
+                associativity=None,
+                to_terms=lambda lhs, rhs: (lhs.to_terms(), rhs.to_terms()),
+                accepts_context=lambda context: all([c.token == "," for c in context]),
+            ),
+            Operator(
+                "=",
+                arity=2,
+                precedence=-100,
+                associativity=None,
+                to_terms=lambda lhs, rhs: add_terms(
+                    lhs.to_terms(), negate_terms(rhs.to_terms())
+                ),
+            ),
+            Operator(
+                "+",
+                arity=2,
+                precedence=100,
+                associativity="left",
+                to_terms=lambda *args: functools.reduce(
+                    add_terms, tuple(arg.to_terms() for arg in args)
+                ),
+            ),
+            Operator(
+                "-",
+                arity=2,
+                precedence=100,
+                associativity="left",
+                to_terms=lambda left, right: sub_terms(
+                    left.to_terms(), right.to_terms()
+                ),
+            ),
+            Operator(
+                "+",
+                arity=1,
+                precedence=100,
+                associativity="right",
+                fixity="prefix",
+                to_terms=lambda arg: arg.to_terms(),
+            ),
+            Operator(
+                "-",
+                arity=1,
+                precedence=100,
+                associativity="right",
+                fixity="prefix",
+                to_terms=lambda arg: negate_terms(arg.to_terms()),
+            ),
+            Operator(
+                "*",
+                arity=2,
+                precedence=200,
+                associativity="left",
+                to_terms=lambda lhs, rhs: mul_terms(lhs.to_terms(), rhs.to_terms()),
+            ),
+            Operator(
+                "/",
+                arity=2,
+                precedence=200,
+                associativity="left",
+                to_terms=lambda lhs, rhs: div_terms(lhs.to_terms(), rhs.to_terms()),
+            ),
+        ]

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 import pytest
 
+import numpy
 import pandas
 from formulaic import Formula
 
@@ -74,6 +75,12 @@ class TestModelSpec:
         m2 = model_spec.get_model_matrix(data2)
         assert isinstance(m2, pandas.DataFrame)
         assert list(m2.columns) == model_spec.feature_names
+
+    def test_get_linear_constraints(self, model_spec):
+        lc = model_spec.get_linear_constraints("`A[T.b]` - a = 3")
+        assert numpy.allclose(lc.constraint_matrix, [[0.0, 1.0, 0.0, -1.0, 0.0, 0.0]])
+        assert lc.constraint_values == [3]
+        assert lc.variable_names == model_spec.feature_names
 
     def test_differentiate(self, model_spec, formula):
         assert model_spec.differentiate("a").formula == formula.differentiate("a")

--- a/tests/utils/test_constraints.py
+++ b/tests/utils/test_constraints.py
@@ -1,0 +1,238 @@
+import re
+
+import numpy
+import pytest
+
+from formulaic.errors import FormulaSyntaxError
+from formulaic.utils.constraints import LinearConstraints, LinearConstraintParser
+
+
+class TestLinearConstraints:
+
+    REF_MATRICES = {
+        1: [[1, 1, 1]],
+        2: [[1, 1, 1], [1, 0, -1]],
+    }
+    REF_VALUES = {
+        1: [0],
+        2: [10, 10],
+    }
+
+    @pytest.mark.parametrize(
+        "check",
+        (
+            # (<case>, <constraints>)
+            (
+                1,
+                LinearConstraints.from_spec(
+                    "a + b + c = 0", variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                1,
+                LinearConstraints.from_spec(
+                    {"a + b + c": 0}, variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                1,
+                LinearConstraints.from_spec(
+                    {"a + b + c = 10": -10}, variable_names=["a", "b", "c"]
+                ),
+            ),
+            (1, LinearConstraints.from_spec([1, 1, 1], variable_names=["a", "b", "c"])),
+            (
+                1,
+                LinearConstraints.from_spec(
+                    ([1, 1, 1], 0), variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                1,
+                LinearConstraints.from_spec(
+                    ([[1, 1, 1]], 0), variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                1,
+                LinearConstraints.from_spec(
+                    ([1, 1, 1], [0]), variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                1,
+                LinearConstraints.from_spec(
+                    ([[1, 1, 1]], [0]), variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                2,
+                LinearConstraints.from_spec(
+                    "a + b + c - 10, a - c = 10", variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                2,
+                LinearConstraints.from_spec(
+                    {"a + b + c": 10, "a - c": 10}, variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                2,
+                LinearConstraints.from_spec(
+                    {"a + b + c = 5": 5, "a - c - 5": 5}, variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                2,
+                LinearConstraints.from_spec(
+                    ([[1, 1, 1], [1, 0, -1]], 10), variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                2,
+                LinearConstraints.from_spec(
+                    ([[1, 1, 1], [1, 0, -1]], [10, 10]), variable_names=["a", "b", "c"]
+                ),
+            ),
+        ),
+    )
+    def test_from_spec(self, check):
+        case, constraints = check
+        assert numpy.allclose(constraints.constraint_matrix, self.REF_MATRICES[case])
+        assert numpy.allclose(constraints.constraint_values, self.REF_VALUES[case])
+
+    def test_from_spec_passthrough(self):
+        constraints = LinearConstraints.from_spec(
+            "a + b + c = 0", variable_names=["a", "b", "c"]
+        )
+        assert LinearConstraints.from_spec(constraints) is constraints
+
+    def test_invalid(self):
+        with pytest.raises(
+            ValueError, match=re.escape("`constraint_matrix` must be a 2D array.")
+        ):
+            LinearConstraints([[[1, 2, 3]]], 0)
+        with pytest.raises(
+            ValueError, match=re.escape("`constraint_values` must be a 1D array.")
+        ):
+            LinearConstraints([[1, 2, 3]], [[1, 2, 3]])
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Number of rows in constraint matrix does not equal the number of values in the values array."
+            ),
+        ):
+            LinearConstraints([[1, 2, 3]], [1, 2])
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Number of column names does not match the number of columns in the linear constraint matrix."
+            ),
+        ):
+            LinearConstraints([[1, 2, 3]], [0], variable_names=["a"])
+
+    def test_n_constraints(self):
+        assert (
+            LinearConstraints.from_spec(
+                "a = 0", variable_names=["a", "b", "c"]
+            ).n_constraints
+            == 1
+        )
+        assert (
+            LinearConstraints.from_spec(
+                "a = 0, b = 0", variable_names=["a", "b", "c"]
+            ).n_constraints
+            == 2
+        )
+
+    def test_str(self):
+        assert (
+            str(LinearConstraints.from_spec("a = b", variable_names=["a", "b", "c"]))
+            == "1.0 * a + -1.0 * b = 0"
+        )
+        assert (
+            str(
+                LinearConstraints.from_spec(
+                    "a = b, a = c", variable_names=["a", "b", "c"]
+                )
+            )
+            == "1.0 * a + -1.0 * b = 0\n1.0 * a + -1.0 * c = 0"
+        )
+
+    def test_show(self, capsys):
+        LinearConstraints.from_spec(
+            "a = b, a = c", variable_names=["a", "b", "c"]
+        ).show()
+        assert (
+            capsys.readouterr().out
+            == "1.0 * a + -1.0 * b = 0\n1.0 * a + -1.0 * c = 0\n"
+        )
+
+    def test_repr(self):
+        assert (
+            repr(
+                LinearConstraints.from_spec(
+                    "a = b, a = c", variable_names=["a", "b", "c"]
+                )
+            )
+            == "<LinearConstraints: 2 constraints>"
+        )
+
+
+class TestLinearConstraintParser:
+
+    COLUMNS = list("abcd")
+
+    TEST_CASES = {
+        "a": ([[1, 0, 0, 0]], [0]),
+        "a + 3 * (a + b - b) / 3 = a": ([[1, 0, 0, 0]], [0]),
+        "a + a": ([[2, 0, 0, 0]], [0]),
+        "a = 10": ([[1, 0, 0, 0]], [10]),
+        "a + b = 10": ([[1, 1, 0, 0]], [10]),
+        "a + b - 10": ([[1, 1, 0, 0]], [10]),
+        "a + b - 10 = 0": ([[1, 1, 0, 0]], [10]),
+        "a = b": ([[1, -1, 0, 0]], [0]),
+        "3 * a + b * 3 = 3": ([[3, 3, 0, 0]], [3]),
+        "a / 3 + 10 / 2 * d = 0": ([[1 / 3, 0, 0, 5]], [0]),
+        "2 * (a + b) - (c + d) / 2": ([[2, 2, -0.5, -0.5]], [0]),
+        "a + b, c + d": ([[1, 1, 0, 0], [0, 0, 1, 1]], [0, 0]),
+        "a + b, c + d = 10": ([[1, 1, 0, 0], [0, 0, 1, 1]], [0, 10]),
+        "a + b = 5, c + d = 10": ([[1, 1, 0, 0], [0, 0, 1, 1]], [5, 10]),
+    }
+
+    @pytest.mark.parametrize("spec,expected", TEST_CASES.items())
+    def test_matrix_output(self, spec, expected):
+        matrix, values = LinearConstraintParser(self.COLUMNS).get_matrix(spec)
+        assert numpy.allclose(matrix, expected[0])
+        assert numpy.allclose(values, expected[1])
+
+    def test_empty(self):
+        matrix, values = LinearConstraintParser(self.COLUMNS).get_matrix("")
+        assert matrix.shape == (0, 4)
+        assert values.shape == (0,)
+
+    def test_string_literals(self):
+        with pytest.raises(
+            FormulaSyntaxError,
+            match=re.escape(
+                "Only numeric literal values are permitted in constraint formulae."
+            ),
+        ):
+            LinearConstraintParser(self.COLUMNS).get_matrix('"a" * a')
+
+    def test_invalid_cases(self):
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                "Only one non-scalar factor can be involved in a linear constraint multiplication."
+            ),
+        ):
+            LinearConstraintParser(self.COLUMNS).get_matrix("a * b")
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                "The right-hand operand must be a scalar in linear constraint division operations."
+            ),
+        ):
+            LinearConstraintParser(self.COLUMNS).get_matrix("a / b")


### PR DESCRIPTION
This patch adds support for linear constraints, which closes out one of the last remaining features in `patsy` that is not also handled by `formulaic`, and the last requirement to satisfy `statsmodels` use-cases. This patch is almost complete, but lacks the following:

- [x] Add utility method on `ModelSpec` instances to build a `LinearConstraints` instance.
- [x] Check over variable names and make sure I'm happy with them.
- [x] Add documentation.

closes #38 