### PR TITLE
Add inline documentation to `Formula`, always use `Structured` for terms, and abstract out `FormulaParser` interface.

### DIFF
--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -1,69 +1,170 @@
+from __future__ import annotations
+
 import inspect
+from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
+
+from typing_extensions import TypeAlias
 
 from .errors import FormulaInvalidError, FormulaMaterializerInvalidError
 from .materializers.base import FormulaMaterializer
-from .parser import FormulaParser
-from .parser.types import Structured, Term
+from .model_matrix import ModelMatrix
+from .parser import DefaultFormulaParser
+from .parser.types import FormulaParser, Structured, Term
 from .utils.calculus import differentiate_term
 
 
+FormulaSpec: TypeAlias = Union[
+    str,
+    List[Union[str, Term]],
+    Set[Union[str, Term]],
+    Structured[Union[str, List[Term], Set[Term]]],
+    "Formula",  # Direct formula specification
+    Dict[str, "FormulaSpec"],
+    Tuple["FormulaSpec", ...],  # Structured formulae
+]
+
+
 class Formula:
+    """
+    A representation of a "formula".
+
+    A formula is basically just a (structured) set of terms to include in the
+    model matrixes, with implicit or explicit encoding choices.
+
+    Attributes:
+        terms: The terms defined by the (parsed) formula.
+    """
+
     @classmethod
-    def from_spec(cls, spec, parser=None):
+    def from_spec(
+        cls,
+        spec: FormulaSpec,
+        parser: Optional[FormulaParser] = None,
+        term_parser: Optional[FormulaParser] = None,
+    ) -> Formula:
+        """
+        Construct a `Formula` instance from a formula specification.
+
+        Args:
+            spec: The formula specification.
+            parser: The `FormulaParser` instance to use when parsing complete
+                formulae (vs. individual terms). If not specified,
+                `DefaultFormulaParser()` is used.
+            term_parser: The `FormulaParser` instance to use when parsing
+                strings describing individual terms (e.g. when `spec` is a
+                list of string term identifiers). If not specified and `parser`
+                is specified, `parser` is used; if `parser` is not specified,
+                `DefaultFormulaParser(include_intercept=False)` is used instead.
+        """
         if isinstance(spec, Formula):
             return spec
-        return cls(spec, parser=parser)
+        return cls(spec, parser=parser, term_parser=term_parser)
 
-    def __init__(self, formula, parser=None):
-        parser = parser or FormulaParser()
-        if isinstance(formula, str):
-            terms = parser.get_terms(formula, sort=True)
-        elif isinstance(formula, (list, set)):
+    terms: Structured[List[Term]]
+
+    def __init__(
+        self,
+        spec: FormulaSpec,
+        parser: Optional[FormulaParser] = None,
+        term_parser: Optional[FormulaParser] = None,
+    ):
+        if isinstance(spec, str):
+            parser = parser or DefaultFormulaParser()
+            terms = parser.get_terms(spec, sort=True)
+        elif isinstance(spec, Formula):
+            terms = spec.terms
+        elif isinstance(spec, (list, set)):
+            term_parser = (
+                term_parser or parser or DefaultFormulaParser(include_intercept=False)
+            )
             terms = [
                 term
-                for value in formula
+                for value in spec
                 for term in (
-                    parser.get_terms(value, include_intercept=False)
-                    if isinstance(value, str)
-                    else [value]
+                    term_parser.get_terms(value) if isinstance(value, str) else [value]
                 )
             ]
-        elif isinstance(formula, tuple):
+        elif isinstance(spec, tuple):
             terms = tuple(
-                Formula.from_spec(group, parser=parser).terms for group in formula
+                Formula.from_spec(group, parser=parser, term_parser=term_parser).terms
+                for group in spec
+            )
+        elif isinstance(spec, Structured):
+            term_parser = (
+                term_parser or parser or DefaultFormulaParser(include_intercept=False)
+            )
+            terms = spec._map(
+                lambda nested_spec: [
+                    term
+                    for value in nested_spec
+                    for term in (
+                        term_parser.get_terms(value)
+                        if isinstance(value, str)
+                        else [value]
+                    )
+                ]
             )
         else:
             raise FormulaInvalidError(
-                f"Unrecognized formula specification: {repr(formula)}."
+                f"Unrecognized formula specification: {repr(spec)}."
             )
         self.terms = terms
 
     @property
-    def terms(self):
+    def terms(self) -> Structured[Term]:
+        """
+        The terms associated with this formula.
+        """
         return self._terms
 
     @terms.setter
-    def terms(self, terms):
+    def terms(self, terms: Union[List[Term], Set[Term], Structured[List[Term]]]):
+        if not isinstance(terms, Structured):
+            terms = Structured(terms)
         self.__check_terms(terms)
         self._terms = terms
 
     @classmethod
-    def __check_terms(cls, terms, depth=0):
+    def __check_terms(cls, terms):
         if isinstance(terms, Structured):
-            terms._map(cls.__check_terms)
-        elif depth == 0 and isinstance(terms, tuple):
-            for termset in terms:
-                cls.__check_terms(termset, depth=depth + 1)
-        else:
-            for term in terms:
-                if not isinstance(term, Term):
-                    raise FormulaInvalidError(
-                        f"All terms in formula should be instances of `formulaic.parser.types.Term`; received term {repr(term)} of type `{type(term)}`."
-                    )
+            return terms._map(cls.__check_terms)
+        if not isinstance(terms, list):
+            # Should be impossible to reach this; here as a sentinel
+            raise FormulaInvalidError(
+                f"All components of a formula should be lists of `Term` instances. Found: {repr(terms)}."
+            )
+        for term in terms:
+            if not isinstance(term, Term):
+                raise FormulaInvalidError(
+                    f"All terms in formula should be instances of `formulaic.parser.types.Term`; received term {repr(term)} of type `{type(term)}`."
+                )
 
     def get_model_matrix(
-        self, data, context=None, materializer=None, ensure_full_rank=True, **kwargs
-    ):
+        self,
+        data: Any,
+        context: Optional[Mapping[str, Any]] = None,
+        materializer: Optional[FormulaMaterializer] = None,
+        ensure_full_rank: bool = True,
+        **kwargs,
+    ) -> Union[ModelMatrix, Structured[ModelMatrix]]:
+        """
+        Build the model matrix (or matrices) realisation of this formula for the
+        nominated `data`.
+
+        Args:
+            data: The data for which to build the model matrices.
+            context: An additional mapping object of names to make available in
+                when evaluating formula term factors.
+            materializer: The `FormulaMatericalizer` class to use when
+                materializing the data. If not specified, an attempt is made to
+                automatically detect this based on the type of `data` (e.g.
+                pandas DataFrames |-> `PandasMaterializer`).
+            ensure_full_rank: Whether to ensure the model matrices are
+                structurally full rank (contain no columns that are guaranteed
+                to be linearly dependent).
+            kwargs: Additional materializer-specific arguments to pass on to the
+                materializer's `.get_model_matrix` method.
+        """
         if materializer is None:
             materializer = FormulaMaterializer.for_data(data)
         else:
@@ -78,9 +179,30 @@ class Formula:
             self, ensure_full_rank=ensure_full_rank, **kwargs
         )
 
-    def differentiate(self, *vars, use_sympy=False):
+    def differentiate(self, *vars: Tuple[str, ...], use_sympy: bool = False):
+        """
+        EXPERIMENTAL: Take the gradient of this formula. When used a linear
+        regression, evaluating a trained model on model matrices generated by
+        this formula is equivalent to estimating the gradient of that fitted
+        form with respect to `vars`.
+
+        Args:
+            vars: The variables with respect to which the gradient should be
+                taken.
+            use_sympy: Whether to use sympy to perform symbolic differentiation.
+
+
+        Notes:
+            This method is provisional and may be removed in any future major
+            version.
+        """
         return Formula(
-            [differentiate_term(term, vars, use_sympy=use_sympy) for term in self.terms]
+            self.terms._map(
+                lambda terms: [
+                    differentiate_term(term, vars, use_sympy=use_sympy)
+                    for term in terms
+                ]
+            )
         )
 
     def __getattr__(self, attr):
@@ -105,14 +227,15 @@ class Formula:
         )
 
     def __str__(self):
-        terms = self.terms
-        if isinstance(self.terms, tuple):
-            terms = Structured(terms)
-        if isinstance(terms, Structured):
+        if (
+            self.terms._has_structure
+            or self.terms._has_root
+            and isinstance(self.terms.root, tuple)
+        ):
             return str(
-                terms._map(lambda terms: " + ".join(str(term) for term in terms))
+                self.terms._map(lambda terms: " + ".join(str(term) for term in terms))
             )
-        return " + ".join(str(term) for term in terms)
+        return " + ".join(str(term) for term in self.terms)
 
     def __eq__(self, other):
         if isinstance(other, Formula):

--- a/formulaic/parser/__init__.py
+++ b/formulaic/parser/__init__.py
@@ -1,6 +1,6 @@
-from .parser import FormulaParser, DefaultOperatorResolver
+from .parser import DefaultFormulaParser, DefaultOperatorResolver
 
 __all__ = [
-    "FormulaParser",
+    "DefaultFormulaParser",
     "DefaultOperatorResolver",
 ]

--- a/formulaic/parser/algos/__init__.py
+++ b/formulaic/parser/algos/__init__.py
@@ -1,0 +1,7 @@
+from .tokenize import tokenize
+from .tokens_to_ast import tokens_to_ast
+
+__all__ = [
+    "tokenize",
+    "tokens_to_ast",
+]

--- a/formulaic/parser/types/__init__.py
+++ b/formulaic/parser/types/__init__.py
@@ -1,5 +1,6 @@
 from .ast_node import ASTNode
 from .factor import Factor
+from .formula_parser import FormulaParser
 from .operator import Operator
 from .operator_resolver import OperatorResolver
 from .structured import Structured
@@ -10,6 +11,7 @@ from .token import Token
 __all__ = [
     "ASTNode",
     "Factor",
+    "FormulaParser",
     "Operator",
     "OperatorResolver",
     "Structured",

--- a/formulaic/parser/types/formula_parser.py
+++ b/formulaic/parser/types/formula_parser.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .ast_node import ASTNode
+from .operator_resolver import OperatorResolver
+from .structured import Structured
+from .term import Term
+from .token import Token
+
+
+@dataclass
+class FormulaParser:
+    """
+    The base formula parser API.
+
+    The role of subclasses of this class is to transform a string representation
+    of a formula into a (structured) sequence of `Term` instances that can be
+    evaluated by materializers and ultimately rendered into model matrices.
+
+    This class can be subclassed to customize this behavior. The three phases of
+    formula parsing are split out into separate methods to make this easier.
+    They are:
+        - get_tokens: Which returns an iterable of `Token` instances. By default
+            this uses `tokenize()` and handles the addition/removal of the
+            intercept.
+        - get_ast: Which converts the iterable of `Token`s into an abstract
+            syntax tree. By default this uses `tokens_to_ast()` and the nominated
+            `OperatorResolver` instance.
+        - get_terms: Which evaluates the abstract syntax tree and returns an
+            iterable of `Term`s.
+    Only the `get_terms()` method is essential from an API perspective.
+    """
+
+    operator_resolver: OperatorResolver
+
+    def get_tokens(self, formula: str) -> Iterable[Token]:
+        """
+        Return an iterable of `Token` instances for the nominated `formula`
+        string.
+
+        Args:
+            formula: The formula string to be tokenized.
+        """
+        from ..algos.tokenize import tokenize
+
+        return tokenize(formula)
+
+    def get_ast(self, formula: str) -> ASTNode:
+        """
+        Assemble an abstract syntax tree for the nominated `formula` string.
+
+        Args:
+            formula: The formula for which an AST should be generated.
+        """
+        from ..algos.tokens_to_ast import tokens_to_ast
+
+        return tokens_to_ast(
+            self.get_tokens(formula),
+            operator_resolver=self.operator_resolver,
+        )
+
+    def get_terms(self, formula: str, *, sort: bool = True) -> Structured[List[Term]]:
+        """
+        Assemble the `Term` instances for a formula string. Depending on the
+        operators involved, this may be an iterable of `Term` instances, or
+        an iterable of iterables of `Term`s, etc.
+
+        Args:
+            formula: The formula for which an AST should be generated.
+            sort: Whether to sort the terms before returning them.
+        """
+        ast = self.get_ast(formula)
+        if ast is None:
+            return Structured([])
+
+        terms = ast.to_terms()
+        if not isinstance(terms, Structured):
+            terms = Structured(terms)
+
+        if sort:
+            terms = terms._map(sorted)
+
+        return terms

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -343,4 +343,4 @@ class TestPandasMaterializer:
         o.seek(0)
         ms2 = pickle.load(o)
         assert isinstance(ms, Structured)
-        assert ms2.lhs.formula.terms == ["a"]
+        assert ms2.lhs.formula.terms.root == ["a"]

--- a/tests/parser/types/test_formula_parser.py
+++ b/tests/parser/types/test_formula_parser.py
@@ -1,0 +1,31 @@
+import pytest
+
+from formulaic.parser.types import FormulaParser
+
+
+FORMULA_TO_TOKENS = {
+    "": [],
+    " ": [],
+    " \n": [],
+    "1": ["1"],
+    "a": ["a"],
+    "a ~ b": ["a", "~", "b"],
+    "a ~": ["a", "~"],
+    "~ 1 + a": ["~", "1", "+", "a"],
+    "0": ["0"],
+    "0 ~": ["0", "~"],
+}
+
+PARSER = FormulaParser(operator_resolver=None)
+
+
+class TestFormulaParser:
+    """
+    Test the base `FormulaParser` API. We only test the `.get_tokens()` method
+    here. See the `DefaultFormulaParser` tests in `../test_parser.py` for a
+    richer set of tests.
+    """
+
+    @pytest.mark.parametrize("formula,tokens", FORMULA_TO_TOKENS.items())
+    def test_get_tokens(self, formula, tokens):
+        assert list(PARSER.get_tokens(formula)) == tokens


### PR DESCRIPTION
This is a pretty large PR that lumps a few changes together (they were scoped out together, and hard to separate out afterwards). In particular, this patch set:

* documents the `Formula` and `FormulaParser` APIs.
* separates out the base `FormulaParser` API from the default implementation (now called `DefaultFormulaParser`).
* has the parser always output `Structured[List[Term]]` objects rather than having to deal with mixed types downstream.