### PR TITLE
Promote `ModelSpec` to be the source of truth for all formula materializations.

### DIFF
--- a/formulaic/__init__.py
+++ b/formulaic/__init__.py
@@ -1,5 +1,5 @@
 from ._version import __author__, __author_email__, __version__
-from .formula import Formula
+from .formula import Formula, FormulaSpec
 from .materializers import FactorValues
 from .model_matrix import ModelMatrix, ModelMatrices
 from .model_spec import ModelSpec, ModelSpecs
@@ -10,6 +10,7 @@ __all__ = [
     "__author_email__",
     "__version__",
     "Formula",
+    "FormulaSpec",
     "ModelMatrix",
     "ModelMatrices",
     "ModelSpec",

--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -259,6 +259,20 @@ class Formula(Structured[List[Term]]):
         )
         return self
 
+    def __getattr__(self, attr):
+        # Keep substructures wrapped to retain access to helper functions.
+        subformula = super().__getattr__(attr)
+        if attr != "root":
+            return Formula.from_spec(subformula)
+        return subformula
+
+    def __getitem__(self, key):
+        # Keep substructures wrapped to retain access to helper functions.
+        subformula = super().__getitem__(key)
+        if key != "root":
+            return Formula.from_spec(subformula)
+        return subformula
+
     def __repr__(self):  # pylint: disable=signature-differs
         if not self._has_structure and self._has_root:
             return " + ".join([str(t) for t in self])

--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import inspect
 import warnings
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple, Union
 
 from typing_extensions import TypeAlias
 
-from .errors import FormulaInvalidError, FormulaMaterializerInvalidError
-from .materializers.base import FormulaMaterializer
+from .errors import FormulaInvalidError
 from .model_matrix import ModelMatrix
 from .parser import DefaultFormulaParser
 from .parser.types import FormulaParser, Structured, Term
@@ -185,12 +183,7 @@ class Formula(Structured[List[Term]]):
                 )
 
     def get_model_matrix(
-        self,
-        data: Any,
-        context: Optional[Mapping[str, Any]] = None,
-        materializer: Optional[FormulaMaterializer] = None,
-        ensure_full_rank: bool = True,
-        **kwargs,
+        self, data: Any, context: Optional[Mapping[str, Any]] = None, **spec_overrides
     ) -> Union[ModelMatrix, Structured[ModelMatrix]]:
         """
         Build the model matrix (or matrices) realisation of this formula for the
@@ -200,28 +193,13 @@ class Formula(Structured[List[Term]]):
             data: The data for which to build the model matrices.
             context: An additional mapping object of names to make available in
                 when evaluating formula term factors.
-            materializer: The `FormulaMatericalizer` class to use when
-                materializing the data. If not specified, an attempt is made to
-                automatically detect this based on the type of `data` (e.g.
-                pandas DataFrames |-> `PandasMaterializer`).
-            ensure_full_rank: Whether to ensure the model matrices are
-                structurally full rank (contain no columns that are guaranteed
-                to be linearly dependent).
-            kwargs: Additional materializer-specific arguments to pass on to the
-                materializer's `.get_model_matrix` method.
+            spec_overrides: Any `ModelSpec` attributes to set/override. See
+                `ModelSpec` for more details.
         """
-        if materializer is None:
-            materializer = FormulaMaterializer.for_data(data)
-        else:
-            materializer = FormulaMaterializer.for_materializer(materializer)
-        if not inspect.isclass(materializer) or not issubclass(
-            materializer, FormulaMaterializer
-        ):
-            raise FormulaMaterializerInvalidError(
-                "Materializers must be subclasses of `formulaic.materializers.FormulaMaterializer`."
-            )
-        return materializer(data, context=context or {}).get_model_matrix(
-            self, ensure_full_rank=ensure_full_rank, **kwargs
+        from .model_spec import ModelSpec
+
+        return ModelSpec.from_spec(self, **spec_overrides).get_model_matrix(
+            data, context=context
         )
 
     def differentiate(  # pylint: disable=redefined-builtin

--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -138,13 +138,7 @@ class Formula(Structured[List[Term]]):
                 ._simplify()
             )
 
-        if isinstance(item, tuple):
-            # Treat each item in the tuple as a top-level formula.
-            formula_or_terms = tuple(
-                Formula(group, _parser=self._parser, _nested_parser=self._nested_parser)
-                for group in item
-            )
-        elif isinstance(item, Structured):
+        if isinstance(item, Structured):
             formula_or_terms = Formula(_parser=self._nested_parser, **item._structure)
         elif isinstance(item, (list, set)):
             formula_or_terms = [
@@ -178,10 +172,6 @@ class Formula(Structured[List[Term]]):
         """
         if isinstance(formula_or_terms, Formula):
             formula_or_terms._map(cls.__validate_prepared_item)
-            return
-        if isinstance(formula_or_terms, tuple):
-            for term in formula_or_terms:
-                cls.__validate_prepared_item(term)
             return
         if not isinstance(formula_or_terms, list):
             # Should be impossible to reach this; here as a sentinel
@@ -270,10 +260,6 @@ class Formula(Structured[List[Term]]):
         return self
 
     def __repr__(self):  # pylint: disable=signature-differs
-        if (
-            not self._has_structure
-            and self._has_root
-            and not isinstance(self.root, tuple)
-        ):
+        if not self._has_structure and self._has_root:
             return " + ".join([str(t) for t in self])
         return str(self._map(lambda terms: " + ".join([str(t) for t in terms])))

--- a/formulaic/parser/types/structured.py
+++ b/formulaic/parser/types/structured.py
@@ -171,6 +171,12 @@ class Structured(Generic[ItemType]):
         for value in self._structure.values():
             if isinstance(value, Structured):
                 yield from value._flatten()
+            elif isinstance(value, tuple):
+                for v in value:
+                    if isinstance(v, Structured):
+                        yield from v._flatten()
+                    else:
+                        yield v
             else:
                 yield value
 

--- a/formulaic/sugar.py
+++ b/formulaic/sugar.py
@@ -1,18 +1,18 @@
 from typing import Any, Mapping, Union
 
-from .formula import Formula
-from .model_matrix import ModelMatrix
-from .model_spec import ModelSpec
+from .formula import FormulaSpec
+from .model_matrix import ModelMatrices, ModelMatrix
+from .model_spec import ModelSpec, ModelSpecs
 from .utils.context import capture_context
 
 
 def model_matrix(
-    spec: Union[Formula, str, list, set, tuple, ModelMatrix, ModelSpec],
+    spec: Union[FormulaSpec, ModelMatrix, ModelMatrices, ModelSpec, ModelSpecs],
     data: Any,
     *,
     context: Union[int, Mapping[str, Any]] = 0,
-    **kwargs
-) -> ModelMatrix:
+    **spec_overrides,
+) -> Union[ModelMatrix, ModelMatrices]:
     """
     Generate a model matrix directly from a formula or model spec.
 
@@ -40,8 +40,8 @@ def model_matrix(
             means that all variables in the caller's scope should be made
             accessible when interpreting and evaluating formulae). Otherwise, a
             mapping from variable name to value is expected.
-        kwargs: Any additional arguments to pass through to the associated
-            `.get_model_matrix()` method.
+        spec_overrides: Any `ModelSpec` attributes to set/override. See
+            `ModelSpec` for more details.
 
     Returns:
         The data transformed in to the model matrix with the requested
@@ -49,9 +49,6 @@ def model_matrix(
     """
     if isinstance(context, int):
         context = capture_context(context + 1)
-
-    if isinstance(spec, ModelMatrix):
-        spec = spec.model_spec
-    elif not isinstance(spec, ModelSpec):
-        spec = Formula.from_spec(spec)
-    return spec.get_model_matrix(data, context=context, **kwargs)
+    return ModelSpec.from_spec(spec, **spec_overrides).get_model_matrix(
+        data, context=context
+    )

--- a/tests/materializers/test_base.py
+++ b/tests/materializers/test_base.py
@@ -29,6 +29,10 @@ class TestFormulaMaterializer:
             is PandasMaterializer
         )
         assert (
+            FormulaMaterializer.for_materializer(PandasMaterializer(pandas.DataFrame()))
+            is PandasMaterializer
+        )
+        assert (
             FormulaMaterializer.for_data(pandas.DataFrame(), output="numpy")
             is PandasMaterializer
         )

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -70,7 +70,7 @@ class TestPandasMaterializer:
 
     def test_get_model_matrix_edge_cases(self, materializer):
         mm = materializer.get_model_matrix(("a",), ensure_full_rank=True)
-        assert isinstance(mm, tuple)
+        assert isinstance(mm, ModelMatrices)
         assert isinstance(mm[0], pandas.DataFrame)
 
         mm = materializer.get_model_matrix("a ~ A", ensure_full_rank=True)
@@ -79,8 +79,8 @@ class TestPandasMaterializer:
         assert "rhs" in mm.model_spec
 
         mm = materializer.get_model_matrix(("a ~ A",), ensure_full_rank=True)
-        assert isinstance(mm, tuple)
-        assert isinstance(mm[0], Structured)
+        assert isinstance(mm, ModelMatrices)
+        assert isinstance(mm[0], ModelMatrices)
 
     @pytest.mark.parametrize("formula,tests", PANDAS_TESTS.items())
     def test_get_model_matrix_numpy(self, materializer, formula, tests):

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -93,7 +93,7 @@ class TestFormulaParser:
     @pytest.mark.parametrize("formula,terms", FORMULA_TO_TERMS.items())
     def test_to_terms(self, formula, terms):
         generated_terms: Structured[List[Term]] = PARSER.get_terms(formula)
-        if generated_terms._has_structure:
+        if generated_terms._has_keys:
             comp = generated_terms._map(sorted)._to_dict()
         elif generated_terms._has_root and isinstance(generated_terms.root, tuple):
             comp = tuple(

--- a/tests/parser/types/test_structured.py
+++ b/tests/parser/types/test_structured.py
@@ -91,6 +91,8 @@ class TestStructured:
         assert set(
             Structured("Hi", a="Hello", b=Structured(c="Greetings"))._flatten()
         ) == {"Hi", "Hello", "Greetings"}
+        assert set(Structured((1, 2), a=3, b=(4, 5))._flatten()) == {1, 2, 3, 4, 5}
+        assert set(Structured((1, Structured(2, b=(3, 4))))._flatten()) == {1, 2, 3, 4}
 
     def test__simplify(self):
         o = object()

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -43,6 +43,11 @@ class TestFormula:
         assert [str(t) for t in f[0]] == ["a", "b"]
         assert [str(t) for t in f[1]] == ["c", "d"]
 
+        f = Formula(("a", ["b", "c"]))
+        assert f._has_structure
+        assert f[0].root == ["1", "a"]
+        assert f[1].root == ["b", "c"]
+
         f = Formula(["a"])
         assert Formula.from_spec(f) is f
         assert Formula.from_spec(["a"]) == f

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -85,9 +85,11 @@ class TestFormula:
         assert isinstance(mm_exprs, Structured) and len(mm_exprs) == 2
 
     def test_structured(self, formula_exprs):
-        assert formula_exprs.lhs == ["a"]
-        assert formula_exprs.rhs == ["1", "b"]
-        assert Formula("a | b")[0] == ["1", "a"]
+        assert formula_exprs.lhs.root == ["a"]
+        assert formula_exprs.rhs.root == ["1", "b"]
+        assert Formula("a | b")[0].root == ["1", "a"]
+        assert isinstance(Formula(["a"], b=["b"])["root"], list)
+        assert isinstance(formula_exprs["lhs"], Formula)
 
         with pytest.raises(
             AttributeError,
@@ -139,5 +141,5 @@ class TestFormula:
         pickle.dump(formula_exprs, o)
         o.seek(0)
         formula = pickle.load(o)
-        assert formula.lhs == ["a"]
-        assert formula.rhs == ["1", "b"]
+        assert formula.lhs.root == ["a"]
+        assert formula.rhs.root == ["1", "b"]


### PR DESCRIPTION
The API for specifying model specs and then materializing from them was a little inconsistent across `Formula`, `ModelSpec(s)`, `FormulaMaterializer` and `model_matrix`. This patch set cleans all of this up by putting `ModelSpec` front and center. It has always been the source of truth (modulo the regression noted in #102), but this patch set makes this role more obvious.

It also deals with a few edge cases, like still being able to access the helper methods when you select a substructure of a `Formula` (e.g. `Formula("y ~ x").lhs`).