### PR TITLE
better wording

### DIFF
--- a/docsite/docs/concepts/grammar.md
+++ b/docsite/docs/concepts/grammar.md
@@ -103,8 +103,7 @@ and conventions of which you should be aware.
     include an intercept term. In R, `b-1` and `(b-1)` both do not have an
     intercept, whereas in Formulaic and Patsy the parentheses are resolved
     first, and so the first does not have an intercept and the second does
-    (because and implicit '1 +' is added prepended to the right hand side of the
-    formula).
+    (because '1 +' is implicitly prepended to the right hand side of the formula).
   - Formulaic borrows a clever algorithm introduced by Patsy to carefully choose
     where to reduce the rank of the model matrix in order to ensure that the
     matrix is structurally full rank. This avoids producing over-specified model


### PR DESCRIPTION
Sidenote: I am also not quite sure I understand how resolving the parentheses _first_ leads to this behaviour, I would think the opposite to be the case. My logic would be if the parenthesis in the example is resolved first, before the prepending of the "1 +", then `(b-1)` first becomes `b-1` and then `1 + b - 1` but that would then be the same as prepending the initial example `b - 1`. In any case There might be an opportunity here to clear up the language or assist with resolution steps.