### PR TITLE
Add support for multi-stage formulae (useful e.g. in IV contexts).

### DIFF
--- a/docsite/docs/guides/grammar.md
+++ b/docsite/docs/guides/grammar.md
@@ -42,9 +42,10 @@ unless otherwise indicated.
 | `+` | 1 | Returns the current term unmodified (not very useful). | ✓ | ✓ | ✓ |
 | `-` | 1 | Negates a term (only implemented for 0, in which case it is replaced with `1`). | ✓ | ✓ | ✓ |
 |-----|
-| `|` | 2 | Splits a formula into multiple parts, allowing the simultaneous generation of multiple model matrices. When on the right-hand-side of the `~` operator, all parts will attract an additional intercept term by default. | ✓ | ✗ | ✓[^6] |
+| `\|` | 2 | Splits a formula into multiple parts, allowing the simultaneous generation of multiple model matrices. When on the right-hand-side of the `~` operator, all parts will attract an additional intercept term by default. | ✓ | ✗ | ✓[^6] |
 |-----|
 | `~` | 1,2 | Separates the target features from the input features. If absent, it is assumed that we are considering only the the input features. Unless otherwise indicated, it is assumed that the input features implicitly include an intercept. | ✓ | ✓ | ✓ |
+| `[ . ~ . ]` | 2 | [Experimental] Multi stage formula notation, which is useful in (e.g.) IV contexts. Requires the `MULTISTAGE` feature flag to be passed to the parser. | ✓ | ✗ | ✗ |
 
 
 ## Transforms

--- a/formulaic/model_spec.py
+++ b/formulaic/model_spec.py
@@ -24,8 +24,8 @@ from .formula import Formula, FormulaSpec
 from .materializers import ClusterBy, FormulaMaterializer, NAAction
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .transforms.contrasts import ContrastsState
     from .model_matrix import ModelMatrices, ModelMatrix
+    from .transforms.contrasts import ContrastsState
 
 # Cached property was introduced in Python 3.8 (we currently support 3.7)
 try:

--- a/formulaic/parser/types/factor.py
+++ b/formulaic/parser/types/factor.py
@@ -99,4 +99,6 @@ class Factor:
         return OrderedSet((Term([self]),))
 
     def __repr__(self) -> str:
+        if ":" in self.expr:
+            return f"`{self.expr}`"
         return self.expr

--- a/formulaic/parser/types/term.py
+++ b/formulaic/parser/types/term.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 if TYPE_CHECKING:
     from .factor import Factor  # pragma: no cover
@@ -15,10 +15,13 @@ class Term:
 
     Attributes:
         factors: The set of factors to be multiplied to form the term.
+        origin: If this `Term` has been derived from another `Term`, for example
+            in subformulae, a reference to the original term.
     """
 
-    def __init__(self, factors: Iterable["Factor"]):
+    def __init__(self, factors: Iterable["Factor"], origin: Optional[Term] = None):
         self.factors = tuple(dict.fromkeys(factors))
+        self.origin = origin
         self._factor_key = tuple(factor.expr for factor in sorted(self.factors))
         self._hash = hash(":".join(self._factor_key))
 

--- a/formulaic/parser/types/term.py
+++ b/formulaic/parser/types/term.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 if TYPE_CHECKING:
@@ -18,6 +19,8 @@ class Term:
         origin: If this `Term` has been derived from another `Term`, for example
             in subformulae, a reference to the original term.
     """
+
+    FACTOR_MATCHER = re.compile(r"(?:^|(?<=:))(`?)(?P<factor>[^`]+?)\1(?=:|$)")
 
     def __init__(self, factors: Iterable["Factor"], origin: Optional[Term] = None):
         self.factors = tuple(dict.fromkeys(factors))
@@ -48,7 +51,9 @@ class Term:
         if isinstance(other, Term):
             return self._factor_key == other._factor_key
         if isinstance(other, str):
-            return self._factor_key == tuple(sorted(other.split(":")))
+            return self._factor_key == tuple(
+                sorted([m.group("factor") for m in self.FACTOR_MATCHER.finditer(other)])
+            )
         return NotImplemented
 
     def __lt__(self, other: Any) -> bool:
@@ -61,4 +66,4 @@ class Term:
         return NotImplemented
 
     def __repr__(self) -> str:
-        return ":".join(factor.expr for factor in self.factors)
+        return ":".join(repr(factor) for factor in self.factors)

--- a/formulaic/transforms/lag.py
+++ b/formulaic/transforms/lag.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, TYPE_CHECKING
+from typing import Any
 
 import numpy
 import pandas

--- a/formulaic/transforms/patsy_compat.py
+++ b/formulaic/transforms/patsy_compat.py
@@ -3,12 +3,12 @@ from typing import Any, Dict, Mapping, Optional
 from formulaic.utils.stateful_transforms import stateful_transform
 
 from .contrasts import (
+    UNSET,
     DiffContrasts,
     HelmertContrasts,
     PolyContrasts,
     SumContrasts,
     TreatmentContrasts,
-    UNSET,
 )
 from .scale import scale
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ dependencies = [
 
 [tool.hatch.envs.lint.scripts]
 check = [
+    "ruff check",
     "ruff format --check",
     "mypy formulaic",
 ]

--- a/tests/parser/types/test_factor.py
+++ b/tests/parser/types/test_factor.py
@@ -52,3 +52,4 @@ class TestFactor:
 
     def test_repr(self):
         assert repr(Factor("a")) == "a"
+        assert repr(Factor("a:b")) == "`a:b`"

--- a/tests/transforms/test_contrasts.py
+++ b/tests/transforms/test_contrasts.py
@@ -10,14 +10,14 @@ from formulaic.errors import DataMismatchWarning
 from formulaic.materializers import FactorValues
 from formulaic.model_spec import ModelSpec
 from formulaic.transforms.contrasts import (
-    ContrastsRegistry as contr,
+    UNSET,
     ContrastsState,
+    SumContrasts,
+    _UnsetSentinel,
+    encode_contrasts,
 )
 from formulaic.transforms.contrasts import (
-    SumContrasts,
-    encode_contrasts,
-    UNSET,
-    _UnsetSentinel,
+    ContrastsRegistry as contr,
 )
 from formulaic.utils.sparse import categorical_encode_series_to_sparse_csc_matrix
 


### PR DESCRIPTION
Hi @bashtage ,

Persuant to #24, I did a quick draft of additional support for IV-like formula in formulaic (in addition to the multi-part formula that was already implemented). There are some bugs and rough edges, but would you mind taking a look and adding any suggestions? I'm also not sure whether this should be a plugin or part of the default stack, so your thoughts there would be helpful too. All naming/etc is in draft status, so you can feel free to suggest improvements there.

Suppose you wanted to model some data using IV. With these patches you could write:
```
>>> from formulaic import Formula
>>> Formula("y ~ x1 + x2 + [ x3 + x4 ~ z1 + z2]")
.lhs:
    y
.rhs:
    root:
        1 + x1 + x2 + x3_hat + x4_hat
    .deps:
        [0]:
            .lhs:
                x3 + x4
            .rhs:
                1 + z1 + z2
```
The resulting formula could then be parsed by the consumer of the formula to do the right things.

If you end up using an interaction term, or later multiplying, formulaic still does the right thing.
```
>>> formulaic.Formula("y ~ x0 + [ x1:x2 ~ z1 + z2 ] : x3")
.lhs:
    y
.rhs:
    root:
        1 + x0 + x1:x2_hat:x3
    .deps:
        [0]:
            .lhs:
                x1:x2
            .rhs:
                1 + z1 + z2
```
The `x1:x2_hat` is considered one factor, and looked up by name.

Note that this could also (with a small amount of effort) also be used for double ML (if we add a `delta` transform/operator), and more general things like:
```
>>> formulaic.Formula("y ~ x1 + x2 + [ x2 + x3 ~ z1 + z2 ] + [ x4 ~ z3 + [z4 ~ a1 + a2 ] ]")
.lhs:
    y
.rhs:
    root:
        1 + x1 + x2 + x2_hat + x3_hat + x4_hat
    .deps:
        [0]:
            .lhs:
                x2 + x3
            .rhs:
                1 + z1 + z2
        [1]:
            .lhs:
                x4
            .rhs:
                root:
                    1 + z3 + z4_hat
                .deps:
                    [0]:
                        .lhs:
                            z4
                        .rhs:
                            1 + a1 + a2
```

Though this does stress credulity a bit.

Lastly, I plan to add some utility methods to Formulaic to allow easy recursive iteration over the formula to assist with the evaluation of dependencies and updating of the dataframe as you go up the tree. This might even be able to be integrated into the high-level tooling, if so desired, with the user passing a `dep_data_resolver` hook of some description.

closes: #24 