### PR TITLE
Make parentheses (and future context scopes) their own token type.

### DIFF
--- a/formulaic/parser/algos/tokenize.py
+++ b/formulaic/parser/algos/tokenize.py
@@ -114,13 +114,13 @@ def tokenize(
                 if token:
                     yield token
                     token = Token(source=formula)
-                yield Token(source=formula).update(char, i, kind="operator")
+                yield Token(source=formula).update(char, i, kind="context")
             continue
         if char in ")":
             if token:
                 yield token
                 token = Token(source=formula)
-            yield Token(source=formula).update(char, i, kind="operator")
+            yield Token(source=formula).update(char, i, kind="context")
             continue
 
         if whitespace_chars.match(char):

--- a/formulaic/parser/types/token.py
+++ b/formulaic/parser/types/token.py
@@ -18,6 +18,7 @@ class Token:
     require any modification of this low-level code.
 
     The four kinds of token are:
+      - context: a token used to scope terms into a given context
       - operator: an operator to be applied to other surrounding tokens (will
             always consist of non-word characters).
       - name: a name of a feature/variable to be lifted from the model matrix
@@ -39,6 +40,7 @@ class Token:
     """
 
     class Kind(Enum):
+        CONTEXT = "context"
         OPERATOR = "operator"
         VALUE = "value"
         NAME = "name"

--- a/tests/parser/algos/test_tokenize.py
+++ b/tests/parser/algos/test_tokenize.py
@@ -13,13 +13,13 @@ TOKEN_TESTS = {
     "a * (b + c:d)": [
         "name:a",
         "operator:*",
-        "operator:(",
+        "context:(",
         "name:b",
         "operator:+",
         "name:c",
         "operator::",
         "name:d",
-        "operator:)",
+        "context:)",
     ],
     "a() + d(a=1, b=2, c  = 3)": [
         "python:a()",

--- a/tests/parser/test_parser.py
+++ b/tests/parser/test_parser.py
@@ -53,6 +53,7 @@ FORMULA_TO_TERMS = {
     # Formula separators
     "~ a + b": ["1", "a", "b"],
     "a ~ b + c": {"lhs": ["a"], "rhs": ["1", "b", "c"]},
+    "a ~ (b + c)": {"lhs": ["a"], "rhs": ["1", "b", "c"]},
     # Formula parts
     "a | b": (["1", "a"], ["1", "b"]),
     "a | b | c": (["1", "a"], ["1", "b"], ["1", "c"]),


### PR DESCRIPTION
This resolves an issue where by formulae like "y ~ (a + b)" would fail due to the automatic insertion of the "1". It also cleans up the ast building code slightly.