### PR TITLE
Add support for operators that affect structure

### DIFF
--- a/formulaic/parser/parser.py
+++ b/formulaic/parser/parser.py
@@ -170,6 +170,7 @@ class DefaultOperatorResolver(OperatorResolver):
                 associativity=None,
                 to_terms=lambda lhs, rhs: Structured(lhs=lhs, rhs=rhs),
                 accepts_context=lambda context: len(context) == 0,
+                structural=True,
             ),
             Operator(
                 "~",
@@ -179,6 +180,7 @@ class DefaultOperatorResolver(OperatorResolver):
                 fixity="prefix",
                 to_terms=lambda terms: terms,
                 accepts_context=lambda context: len(context) == 0,
+                structural=True,
             ),
             Operator(
                 "|",
@@ -189,6 +191,7 @@ class DefaultOperatorResolver(OperatorResolver):
                 accepts_context=lambda context: all(
                     isinstance(c, Operator) and c.symbol in "~|" for c in context
                 ),
+                structural=True,
             ),
             Operator(
                 "+",

--- a/formulaic/parser/types/operator.py
+++ b/formulaic/parser/types/operator.py
@@ -33,6 +33,10 @@ class Operator:
         accepts_context: A callable that will receive a list of Operator and
             Token instances that describe the context in which the operator
             would be applied if this callable returns `True`.
+        structural: Whether this operator adds structure to the terms sets, in
+            which case `Structured._merge` will not be used in the
+            `ASTNode.to_terms()`, and the termsets will be directly passed to
+            `Operator.to_terms()`.
     """
 
     class Associativity(Enum):
@@ -55,6 +59,7 @@ class Operator:
         fixity: Union[str, Fixity] = "infix",
         to_terms: Callable[..., Iterable[Term]] = None,
         accepts_context: Callable[[List[Union[Token, Operator]]], bool] = None,
+        structural: bool = False,
     ):
         self.symbol = symbol
         self.arity = arity
@@ -63,6 +68,7 @@ class Operator:
         self.fixity = fixity
         self._to_terms = to_terms
         self._accepts_context = accepts_context
+        self.structural = structural
 
     @property
     def associativity(self):

--- a/formulaic/parser/types/structured.py
+++ b/formulaic/parser/types/structured.py
@@ -340,7 +340,7 @@ class Structured(Generic[ItemType]):
         self._structure[key] = self.__prepare_item(key, value)
 
     def __iter__(self) -> Generator[Union[ItemType, Structured[ItemType]]]:
-        if self._has_root and not self._has_keys and isinstance(self.root, Sequence):
+        if self._has_root and not self._has_keys and isinstance(self.root, Iterable):
             yield from self.root
         else:
             if self._has_root:  # Always yield root first.

--- a/formulaic/parser/types/structured.py
+++ b/formulaic/parser/types/structured.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import itertools
+from collections import defaultdict
 from typing import (
     Any,
     Callable,
     Dict,
     Generator,
     Generic,
+    Iterable,
     Optional,
-    Sequence,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -298,6 +301,99 @@ class Structured(Generic[ItemType]):
                     for key, item in structure.items()
                 },
             }
+        )
+
+    @classmethod
+    def _merge(
+        cls,
+        *objects: Any,
+        merger: Callable[..., ItemType] = None,
+        _context: Tuple[str, ...] = (),
+    ) -> Union[ItemType, Structured[ItemType]]:
+        """
+        Merge arbitrarily many objects into a single `Structured` instance.
+
+        If any of `objects` are `Structured` or `tuple` instances, then all
+        `objects` will be treated as `Structured` instances (being upcast as
+        necessary) and then merged recursively; otherwise the objects will be
+        merged directly by `merger`.
+
+        Note: An empty set of objects will result in an empty `Structured`
+        instance being returned.
+
+        Args:
+            objects: A tuple of Structured instances (will be upcast to a
+                trivial `Structured` instance as necessary).
+            merger: A callable which takes as arguments two or more items which
+                are to be merged. If not provided, a basic fallback is provided
+                that knows how to merge lists, dictionaries and sets.
+            _context: A string representing the context of the merge. Intended
+                for internal use.
+        """
+        if merger is None:
+            merger = cls.__merger_default
+
+        # If objects are not specified, return an empty `Structured` instance.
+        if not objects:
+            return cls()
+
+        # Check for sequential (tuple) structures, and if so merge them and
+        # return them wrapped in a `Structured` instance.
+        all_tuples = all(isinstance(obj, tuple) for obj in objects)
+        any_tuples = any(isinstance(obj, tuple) for obj in objects)
+
+        if any_tuples and not all_tuples:
+            raise ValueError(
+                f"Substructures for `.{'.'.join(_context)}` are not aligned and cannot be merged."
+            )
+
+        if all_tuples:
+            merged = tuple(itertools.chain(*objects))
+            if _context:
+                # We are merging substructure of `Structured` instances (and don't need the class wrapper)
+                return merged
+            return cls(merged)
+
+        # Check whether all objects are not Structured instances (or tuples,
+        # already excluded by above). If so, just call `merger` on them
+        # directly.
+        if all(not isinstance(obj, Structured) for obj in objects):
+            return merger(*objects)
+
+        # Otherwise,iterate over objects, upcasting to `Structured` as necessary
+        # and recursively merge them by merging their structure dictionaries.
+        values_to_merge = defaultdict(list)
+
+        for obj in objects:
+            if isinstance(obj, Structured):
+                for key, value in obj._structure.items():
+                    values_to_merge[key].append(value)
+            else:
+                values_to_merge["root"].append(obj)
+
+        return cls(
+            **{
+                key: (
+                    cls._merge(*values, merger=merger, _context=_context + (key,))
+                    if len(values) > 1
+                    else values[0]
+                )
+                for key, values in values_to_merge.items()
+            }
+        )
+
+    @staticmethod
+    def __merger_default(*items):
+        if all(isinstance(item, list) for item in items):
+            return list(itertools.chain(*items))
+        if all(isinstance(item, set) for item in items):
+            return set.union(*items)
+        if all(isinstance(item, dict) for item in items):
+            return dict(itertools.chain(*(d.items() for d in items)))
+        raise NotImplementedError(
+            "The fallback `merger` for `Structured._merge` does not know how to "
+            f"merge objects of types {repr(tuple(type(item) for item in items))}. "
+            "Please specify `merger` explicitly."
         )
 
     def __dir__(self):

--- a/formulaic/utils/constraints.py
+++ b/formulaic/utils/constraints.py
@@ -441,6 +441,7 @@ class ConstraintOperatorResolver(
                 associativity=None,
                 to_terms=join_tuples,
                 accepts_context=lambda context: all(c.symbol == "," for c in context),
+                structural=True,
             ),
             Operator(
                 "=",

--- a/tests/parser/types/test_structured.py
+++ b/tests/parser/types/test_structured.py
@@ -43,7 +43,7 @@ class TestStructured:
             Structured()["root"]
 
         s2 = Structured({"my_key": "my_value"})
-        assert list(s2) == [{"my_key": "my_value"}]
+        assert list(s2) == ["my_key"]
         assert s2["my_key"] == "my_value"
 
         s3 = Structured(["a", "b"])
@@ -114,7 +114,7 @@ class TestStructured:
 
     def test__update(self):
         o = object()
-        assert Structured(o), _update([o]) == Structured([o])
+        assert Structured(o)._update([o]) == Structured([o])
         assert Structured()._update(key=o) == Structured(key=o)
         assert Structured(1, key=2)._update(3) == Structured(3, key=2)
         assert Structured(_metadata={"a": 1})._update()._metadata == {"a": 1}


### PR DESCRIPTION
This PR mainlines the framework pieces of #108, allowing operators to collect terms in different groups or substructures (such as collecting random effect terms separately from fixed effect terms; or adding support for IV subformulae/etc.