### PR TITLE
Add support for the patsy `Q` transform.

### DIFF
--- a/docsite/docs/guides/grammar.md
+++ b/docsite/docs/guides/grammar.md
@@ -57,6 +57,7 @@ that have *not* been implemented by `formulaic` are explicitly noted also.
 | Transform | Description | Formulaic | Patsy | R |
 |----------:|:------------|:---------:|:-----:|:-:|
 | `I(...)` | Identity transform, allowing arbitrary Python/R operations, e.g. `I(x+y)`. Note that in `formulaic`, it is more idiomatic to use `{x+y}`. | ✓ | ✓ | ✓ |
+| `Q('<column_name>')` | Look up feature by potentially exotic name, e.g. `Q('wacky name!')`. Note that in `formulaic`, it is more idiomatic to use ``` `wacky name!` ```. | ✓ | ✓ | ✗ |
 | `C(...)` | Categorically encode a column, e.g. `C(x)` | ✓ | ✓ | ✓ |
 | `center(...)` | Shift column data so mean is zero. | ✓ | ✓ | ✗ |
 | `scale(...)` | Shift column so mean is zero and variance is 1. | ✓ | ✓[^6] | ✓ |

--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -125,7 +125,9 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
         self._init()
 
         self.layered_context = LayeredMapping(
-            self.data_context, self.context, TRANSFORMS
+            LayeredMapping(self.data_context, name="data"),
+            LayeredMapping(self.context, name="context"),
+            LayeredMapping(TRANSFORMS, name="transforms"),
         )
 
         self.factor_cache = {}

--- a/formulaic/transforms/patsy_compat.py
+++ b/formulaic/transforms/patsy_compat.py
@@ -19,8 +19,14 @@ def Treatment(reference=TreatmentContrasts.MISSING):
     return TreatmentContrasts(base=reference)
 
 
+@stateful_transform
+def Q(variable, _context=None):
+    return _context.data[variable]
+
+
 PATSY_COMPAT_TRANSFORMS = {
     "standardize": standardize,
+    "Q": Q,
     "Treatment": Treatment,
     "Poly": PolyContrasts,
     "Sum": SumContrasts,

--- a/formulaic/utils/layered_mapping.py
+++ b/formulaic/utils/layered_mapping.py
@@ -2,6 +2,12 @@ import itertools
 from collections.abc import MutableMapping
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
+# Cached property was introduced in Python 3.8 (we currently support 3.7)
+try:
+    from functools import cached_property
+except ImportError:  # pragma: no cover
+    from cached_property import cached_property
+
 
 class LayeredMapping(MutableMapping):
     """
@@ -10,15 +16,19 @@ class LayeredMapping(MutableMapping):
     bottom until the key is found or the stack is exhausted. Mutations are
     stored in an additional layer local only to the `LayeredMapping` instance,
     and the layers passed in are never mutated.
+
+    Nest named layers can be extracted via attribute lookups, or via
+    `.named_layers`.
     """
 
-    def __init__(self, *layers: Tuple[Optional[Mapping]]):
+    def __init__(self, *layers: Tuple[Optional[Mapping]], name: Optional[str] = None):
         """
         Crepare a `LayeredMapping` instance, populating it with the nominated
         layers.
         """
-        self.mutations: Dict = {}
-        self.layers: List[Mapping] = self.__filter_layers(layers)
+        self.name = name
+        self._mutations: Dict = {}
+        self._layers: List[Mapping] = self.__filter_layers(layers)
 
     @staticmethod
     def __filter_layers(layers: Iterable[Mapping]) -> List[Mapping]:
@@ -28,36 +38,37 @@ class LayeredMapping(MutableMapping):
         return [layer for layer in layers if layer is not None]
 
     def __getitem__(self, key: Any) -> Any:
-        for layer in [self.mutations, *self.layers]:
+        for layer in [self._mutations, *self._layers]:
             if key in layer:
                 return layer[key]
         raise KeyError(key)
 
     def __setitem__(self, key: Any, value: Any):
-        self.mutations[key] = value
+        self._mutations[key] = value
 
     def __delitem__(self, key: Any):
-        if key in self.mutations:
-            del self.mutations[key]
+        if key in self._mutations:
+            del self._mutations[key]
         else:
             raise KeyError(f"Key '{key}' not found in mutable layer.")
 
     def __iter__(self):
         keys = set()
-        for layer in [self.mutations, *self.layers]:
+        for layer in [self._mutations, *self._layers]:
             for key in layer:
                 if key not in keys:
                     keys.add(key)
                     yield key
 
     def __len__(self):
-        return len(set(itertools.chain(self.mutations, *self.layers)))
+        return len(set(itertools.chain(self._mutations, *self._layers)))
 
     def with_layers(
         self,
         *layers: Tuple[Optional[Mapping]],
         prepend: bool = True,
         inplace: bool = False,
+        name: Optional[str] = None,
     ) -> "LayeredMapping":
         """
         Return a copy of this `LayeredMapping` instance with additional layers
@@ -78,10 +89,34 @@ class LayeredMapping(MutableMapping):
             return self
 
         if inplace:
-            self.layers = (
-                [*layers, *self.layers] if prepend else [*self.layers, *layers]
+            self._layers = (
+                [*layers, *self._layers] if prepend else [*self._layers, *layers]
             )
+            self.name = name
+            if "named_layers" in self.__dict__:
+                del self.named_layers
             return self
 
         new_layers = [*layers, self] if prepend else [self, *layers]
-        return LayeredMapping(*new_layers)
+        return LayeredMapping(*new_layers, name=name)
+
+    # Named layer lookups and caching
+
+    @cached_property
+    def named_layers(self):
+        named_layers = {}
+        local = {}
+        for layer in reversed(self._layers):
+            if isinstance(layer, LayeredMapping):
+                if layer.name:
+                    local[layer.name] = layer
+                named_layers.update(layer.named_layers)
+        named_layers.update(local)
+        if self.name:
+            named_layers[self.name] = self
+        return named_layers
+
+    def __getattr__(self, attr):
+        if attr not in self.named_layers:
+            raise AttributeError(f"{repr(attr)} does not correspond to a named layer.")
+        return self.named_layers[attr]

--- a/tests/transforms/test_patsy_compat.py
+++ b/tests/transforms/test_patsy_compat.py
@@ -21,3 +21,9 @@ def test_Treatment():
         ).values
         == numpy.array([[1, 0, 0], [1, 1, 0], [1, 0, 1]])
     )
+
+
+def test_Q():
+    assert model_matrix(
+        "Q('x')", pandas.DataFrame({"x": [1, 2, 3]})
+    ).model_spec.column_names == ("Intercept", "Q('x')")


### PR DESCRIPTION
Motivated by #115 , this is a quick draft demonstrating a `Q` transform that replicates the behavior of the patsy `Q` function.

Notes:
- This syntax is not as nice as ``....``, but may be valuable when users are migrating over to formulaic from patsy.
- Perhaps this should be gated by a patsy compatibility flag.
- Perhaps `_data` and `_context` should be passed in separately, to avoid name collisions / weird data types.
- Perhaps it isn't worth adding at all? And just have people migrate over to ``...`` syntax, or furnish formulaic with their own `Q` implementation (only merge the context bits).

Closes: #115 