### PR TITLE
FIX: Coerce numpy.multiply arguments to arrays

### DIFF
--- a/formulaic/materializers/pandas.py
+++ b/formulaic/materializers/pandas.py
@@ -118,7 +118,7 @@ class PandasMaterializer(FormulaMaterializer):
                     {
                         ":".join(solo_factors): functools.reduce(
                             numpy.multiply,
-                            (p for p in solo_factors.values()),
+                            (numpy.asanyarray(p) for p in solo_factors.values()),
                         )
                     }
                 )


### PR DESCRIPTION
This resolves the warning that appears in tests:

```
=============================== warnings summary ===============================
tests/test_formula.py::TestFormula::test_get_model_matrix
tests/test_formula.py::TestFormula::test_get_model_matrix
tests/test_formula.py::TestFormula::test_get_model_matrix
tests/test_formula.py::TestFormula::test_get_model_matrix
  /home/runner/work/formulaic/formulaic/formulaic/materializers/pandas.py:119: DeprecationWarning: The __array_wrap__ method of DataFrame and Series will be removed in a future version
    ":".join(solo_factors): functools.reduce(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

At least in tests, this is a `pd.Series`, but I'm not positive that it always is, so I used `np.asanyarray()` instead of `p.values`.