### PR TITLE
Remove pin on `sympy` given that 1.10.1 fixes the regression that broke formulaic.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ documentation = "https://matthewwardrop.github.io/formulaic"
 
 [project.optional-dependencies]
 arrow = ["pyarrow>=1"]
-calculus = ["sympy<1.10,>=1.3"]
+calculus = ["sympy>=1.3,!=1.10"]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
Sympy 1.10 broke Formulaic, but it turns out this was just a regression that was fixed in Sympy 1.10.1.

Closes #132 