### PR TITLE
Add License to PyPI classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Adds license to [PyPI project classifiers](https://pypi.org/classifiers/)

The reason that it is very important for this information to be present is that in an enterprise environment, security tools like [Sonatype Nexus IQ](https://help.sonatype.com/iqserver) are used to manage open source software risk. Nexus IQ specifically can be configured to [classify packages according to their license](https://help.sonatype.com/iqserver/managing/policy-management/license-threat-groups). This prevents developers from inadvertently using licenses like [GNU General Public License v2.0](https://www.tldrlegal.com/license/gnu-general-public-license-v2) without realizing that they may be legally obligated to make their entire project open source.

My understanding is that Nexus IQ uses the classifiers panel to determine a project's license.
Because Formulaic does not currently include the license in the classifiers panel, Nexus cannot determine the license and treats Formulaic as a high-risk package.
![image](https://github.com/matthewwardrop/formulaic/assets/7910938/a5dfca00-ee75-43bf-8fcd-b8461122be1d)

Adding this license information will increase the availability of Formulaic within enterprise environments.

I have made similar PR's for [Gradio](https://github.com/gradio-app/gradio/pull/4383) with excellent results.