### PR TITLE
Add support for tracking variable usage in formulae.

### DIFF
--- a/docsite/docs/guides/model_specs.ipynb
+++ b/docsite/docs/guides/model_specs.ipynb
@@ -87,6 +87,17 @@
     "    * **term_slices**: An ordered mapping of `Term` instances to a slice that \n",
     "        when used on the columns of the model matrix will subsample the model\n",
     "        matrix down to those corresponding to each term.\n",
+    "    * **term_variables**: An order mapping of `Term` instances to `Variable`\n",
+    "        instances (a string subclass with addition attributes of `roles` and \n",
+    "        `source`), indicating the variables used by that term.\n",
+    "    * **variable_terms**: The reverse lookup of the above.\n",
+    "    * **variable_indices**: A mapping from `Variable` instance to the indices\n",
+    "        of the columns in the model matrix that variable.\n",
+    "    * **variables**: A set of `Variable` instances describing the variables\n",
+    "        used in entire formula.\n",
+    "    * **variables_by_source**: A mapping from source name (typically one of \n",
+    "        `\"data\"`, `\"context\"`, or `\"transforms\"`) to the variables derived from\n",
+    "        that source.\n",
     "* Utility methods:\n",
     "    * **get_model_matrix(...)**: Build a model matrix using this spec. This \n",
     "        allows a new dataset to be generated using exactly the same encoding \n",
@@ -235,7 +246,14 @@
        " 'term_indices': OrderedDict([(1, [0]), (center(a), [1]), (b, [2, 3])]),\n",
        " 'term_slices': OrderedDict([(1, slice(0, 1, None)),\n",
        "              (center(a), slice(1, 2, None)),\n",
-       "              (b, slice(2, 4, None))])}"
+       "              (b, slice(2, 4, None))]),\n",
+       " 'term_variables': OrderedDict([(1, set()),\n",
+       "              (center(a), {'a', 'center'}),\n",
+       "              (b, {'b'})]),\n",
+       " 'variable_terms': {'center': {center(a)}, 'a': {center(a)}, 'b': {b}},\n",
+       " 'variable_indices': {'center': [1], 'a': [1], 'b': [2, 3]},\n",
+       " 'variables': {'a', 'b', 'center'},\n",
+       " 'variables_by_source': {'data': {'a', 'b'}, 'transforms': {'center'}}}"
       ]
      },
      "execution_count": 3,
@@ -251,6 +269,11 @@
     "    \"terms\": ms.terms,\n",
     "    \"term_indices\": ms.term_indices,\n",
     "    \"term_slices\": ms.term_slices,\n",
+    "    \"term_variables\": ms.term_variables,\n",
+    "    \"variable_terms\": ms.variable_terms,\n",
+    "    \"variable_indices\": ms.variable_indices,\n",
+    "    \"variables\": ms.variables,\n",
+    "    \"variables_by_source\": ms.variables_by_source,\n",
     "}"
    ]
   },
@@ -422,7 +445,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/matthew/Repositories/github/formulaic/formulaic/transforms/contrasts.py:124: DataMismatchWarning: Data has categories outside of the nominated levels (or that were not seen in original dataset): {'D'}. They are being  cast to nan, which will likely skew the results of your analyses.\n",
+      "/home/matthew/Repositories/github/formulaic/formulaic/transforms/contrasts.py:155: DataMismatchWarning: Data has categories outside of the nominated levels (or that were not seen in original dataset): {'D'}. They are being  cast to nan, which will likely skew the results of your analyses.\n",
       "  warnings.warn(\n"
      ]
     },

--- a/formulaic/materializers/types/evaluated_factor.py
+++ b/formulaic/materializers/types/evaluated_factor.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, Optional, Set
 
 from formulaic.parser.types import Factor
+from formulaic.utils.variables import Variable
 
 from .factor_values import FactorValues, FactorValuesMetadata
 
@@ -19,10 +20,14 @@ class EvaluatedFactor:
     Attributes:
         factor: The `Factor` instance for which values have been computed.
         values: The evaluated values for the factor.
+        variables: A mapping from the names of variables used during evaluation
+            to the name of the `LayeredMapping` instance from which it was
+            drawn.
     """
 
     factor: Factor
     values: FactorValues[Any]
+    variables: Optional[Set[Variable]] = None
 
     @property
     def expr(self) -> str:

--- a/formulaic/materializers/types/scoped_term.py
+++ b/formulaic/materializers/types/scoped_term.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Set
+
+from formulaic.utils.variables import Variable
+
 from .scoped_factor import ScopedFactor
 
 
@@ -58,3 +61,13 @@ class ScopedTerm:
                 for factor in factors
             ]
         return ScopedTerm(factors, scale=self.scale)
+
+    @property
+    def variables(self) -> Set[Variable]:
+        return Variable.union(
+            *(
+                factor.factor.variables
+                for factor in self.factors
+                if factor.factor.variables is not None
+            )
+        )

--- a/formulaic/utils/stateful_transforms.py
+++ b/formulaic/utils/stateful_transforms.py
@@ -173,7 +173,7 @@ def stateful_eval(
         )
 
     # Compile mutated AST
-    code = compile(ast.fix_missing_locations(code), "", "eval")
+    compiled = compile(ast.fix_missing_locations(code), "", "eval")
 
     assert "__FORMULAIC_CONTEXT__" not in env
     assert "__FORMULAIC_METADATA__" not in env
@@ -182,7 +182,7 @@ def stateful_eval(
 
     # Evaluate and return
     return eval(
-        code,
+        compiled,
         {},
         LayeredMapping(
             {

--- a/formulaic/utils/variables.py
+++ b/formulaic/utils/variables.py
@@ -1,0 +1,92 @@
+# AST variable extraction
+from __future__ import annotations
+
+import ast
+from collections import deque
+from enum import Enum
+from typing import Dict, Iterable, List, Mapping, Optional, Set, Union
+
+from formulaic.utils.layered_mapping import LayeredMapping
+
+
+class Variable(str):
+    class Role(str, Enum):
+        VALUE = "value"
+        CALLABLE = "callable"
+
+    roles: Set[Role]
+    source: Optional[str]
+
+    def __new__(
+        cls,
+        name: str,
+        *,
+        roles: Optional[Iterable[str]] = None,
+        source: Optional[str] = None,
+    ) -> Variable:
+        s = str.__new__(cls, str(name))
+        s.roles = {cls.Role(role) for role in (roles or ())}
+        s.source = source
+        return s
+
+    @classmethod
+    def union(cls, *variable_sets: Set[Variable]) -> Set[Variable]:
+        variables: Dict[Variable, Variable] = {}
+        for variable_set in variable_sets:
+            for variable in variable_set:
+                if variable in variables:
+                    variables[variable] = Variable(
+                        str(variable),
+                        roles=variable.roles | variables[variable].roles,
+                        source=variable.source,
+                    )
+                else:
+                    variables[variable] = variable
+        return set(variables.values())
+
+
+def get_expression_variables(
+    expr: Union[str, ast.AST], context: Mapping
+) -> Set[Variable]:
+    if isinstance(expr, str):
+        expr = ast.parse(expr, mode="eval")
+    variables = _get_ast_node_variables(expr)
+
+    if isinstance(context, LayeredMapping):
+        out = set()
+        for variable in variables:
+            variable.source = context.get_layer_name_for_key(variable.split(".", 1)[0])
+            out.add(variable)
+        return out
+    return set(variables)
+
+
+def _get_ast_node_variables(node: ast.AST) -> List[Variable]:
+    variables: List[Variable] = []
+
+    todo = deque([node])
+    while todo:
+        node = todo.popleft()
+        if isinstance(node, ast.Call):
+            variables.append(Variable(_get_ast_node_name(node), roles=["callable"]))
+            todo.extend(node.args)
+            todo.extend(node.keywords)
+        elif isinstance(node, (ast.Attribute, ast.Name)):
+            variables.append(Variable(_get_ast_node_name(node), roles=["value"]))
+        else:
+            todo.extend(ast.iter_child_nodes(node))
+
+    return variables
+
+
+def _get_ast_node_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Call):
+        return _get_ast_node_name(node.func)
+    if isinstance(node, ast.Attribute):
+        return f"{_get_ast_node_name(node.value)}.{node.attr}"
+    raise ValueError(  # pragma: no cover
+        f"Unknown AST node type during variable extraction: {type(node)}. "
+        "Please report this!"
+    )

--- a/tests/materializers/types/test_scoped_term.py
+++ b/tests/materializers/types/test_scoped_term.py
@@ -1,13 +1,23 @@
 import pytest
 
-from formulaic.materializers.types import ScopedFactor, ScopedTerm
+from formulaic.materializers.types import ScopedFactor, ScopedTerm, EvaluatedFactor
 from formulaic.parser.types import Factor
+from formulaic.utils.variables import Variable
 
 
 class TestScopedTerm:
     @pytest.fixture
     def scoped_term(self):
-        return ScopedTerm([ScopedFactor(Factor("a")), ScopedFactor(Factor("b"))])
+        return ScopedTerm(
+            [
+                ScopedFactor(
+                    EvaluatedFactor(Factor("a"), values=[1], variables={Variable("a")})
+                ),
+                ScopedFactor(
+                    EvaluatedFactor(Factor("b"), values=[1], variables={Variable("b")})
+                ),
+            ]
+        )
 
     @pytest.fixture
     def scoped_term_empty(self):
@@ -31,3 +41,6 @@ class TestScopedTerm:
         assert copied is not scoped_term
         assert copied.factors == scoped_term.factors
         assert copied.scale == scoped_term.scale
+
+    def test_variables(self, scoped_term):
+        assert scoped_term.variables == {"a", "b"}

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -91,6 +91,19 @@ class TestModelSpec:
             ]
         )
         assert model_spec.terms == ["1", "a", "A", "A:a"]
+        assert model_spec.term_variables == {
+            "1": set(),
+            "a": {"a"},
+            "A": {"A"},
+            "A:a": {"a", "A"},
+        }
+        assert model_spec.variable_terms == {"a": {"a", "A:a"}, "A": {"A", "A:a"}}
+        assert model_spec.variable_indices == {
+            "a": [1, 4, 5],
+            "A": [2, 3, 4, 5],
+        }
+        assert model_spec.variables == {"a", "A"}
+        assert model_spec.variables_by_source == {"data": {"a", "A"}}
 
     @pytest.mark.filterwarnings(
         r"ignore:`ModelSpec\.feature_names` is deprecated.*:DeprecationWarning"
@@ -208,3 +221,13 @@ class TestModelSpec:
             ),
         ):
             model_spec.term_indices
+
+        with pytest.raises(
+            RuntimeError,
+            match=re.escape(
+                "`ModelSpec.structure` has not yet been populated. This will "
+                "likely be resolved by using the `ModelSpec` instance attached "
+                "to the model matrix generated when calling `.get_model_matrix()`."
+            ),
+        ):
+            model_spec.term_variables

--- a/tests/utils/test_layered_mapping.py
+++ b/tests/utils/test_layered_mapping.py
@@ -64,3 +64,10 @@ def test_named_layered_mappings():
         match=re.escape("'missing' does not correspond to a named layer."),
     ):
         layers.missing
+
+    full_layers = LayeredMapping(data_layer, context_layer, name="toplevel")
+    full_layers["local"] = True
+    assert full_layers.get_with_layer_name("local") == (True, "toplevel")
+    assert full_layers.get_with_layer_name("data") == (1, "toplevel:data")
+    assert full_layers.get_with_layer_name("missing") == (None, None)
+    assert full_layers.get_layer_name_for_key("data") == "toplevel:data"

--- a/tests/utils/test_variables.py
+++ b/tests/utils/test_variables.py
@@ -1,0 +1,35 @@
+from formulaic.utils.layered_mapping import LayeredMapping
+from formulaic.utils.variables import Variable, get_expression_variables
+
+
+def test_get_expression_variables():
+    assert get_expression_variables("a + b", {}) == {"a", "b"}
+    variables = get_expression_variables(
+        "a + b * c.d",
+        LayeredMapping(
+            {"a": 1},
+            LayeredMapping(
+                {"b": 1},
+                LayeredMapping({"c": 1}, name="subchild"),
+                name="child",
+            ),
+        ),
+    )
+    assert variables == {"a", "b", "c.d"}
+    vd = {variable: variable for variable in variables}
+    assert vd["a"].source is None
+    assert vd["b"].source == "child"
+    assert vd["c.d"].source == "child:subchild"
+
+
+class test_variable:
+    v_a = Variable("a", roles=["value"], source="data")
+    v_a_2 = Variable("a", roles=["callable"], source="data")
+    v_b = Variable("b", roles=["value"], source="data")
+
+    combined = {v: v for v in Variable.union({v_a}, {v_a_2, v_b})}
+    assert combined["a"].roles == {"value", "callable"}
+    assert combined["a"].source == "data"
+    assert combined["b"].roles == {"value"}
+    assert combined["b"].source == "data"
+    assert len(combined) == 2


### PR DESCRIPTION
As per #32 and #60, it is sometimes useful to be able to look up which variables were used by the formula and its terms. This can be used to slice columns, or to determine data requirements for subsequent model evaluations.

This patchset adds support for tracking this information during model matric materialization, which is exposed as attributes of the `ModelSpec`; that is: 

```
>>> import pandas
>>> from formulaic import Formula
>>> df = pandas.DataFrame({'a': [1,2,3], 'b': [4,5,6]})
>>> mm = Formula("a + b + bs(b) + C(a, contr.treatment)").get_model_matrix(df)
>>> mm.term_variables
OrderedDict([(1, {}),
             (a, {'a': 'data'}),
             (b, {'b': 'data'}),
             (bs(b), {'bs()': 'transforms', 'b': 'data'}),
             (C(a, contr.treatment),
              {'C()': 'transforms',
               'a': 'data',
               'contr.treatment': 'transforms'})])
>>> mm.variable_terms
defaultdict(set,
            {'a': {C(a, contr.treatment), a},
             'b': {b, bs(b)},
             'bs()': {bs(b)},
             'C()': {C(a, contr.treatment)},
             'contr.treatment': {C(a, contr.treatment)}})
>>> mm.variable_indices
{'a': [1, 6, 7],
 'b': [2, 3, 4, 5],
 'bs()': [3, 4, 5],
 'C()': [6, 7],
 'contr.treatment': [6, 7]}
>>> mm.required_data_variables
{'a', 'b'}
```

closes: #32 
closes: #60