### PR TITLE
Fix quoting of variables used in Python calls.

### DIFF
--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -43,7 +43,7 @@ from formulaic.transforms import TRANSFORMS
 from formulaic.utils.cast import as_columns
 from formulaic.utils.layered_mapping import LayeredMapping
 from formulaic.utils.stateful_transforms import stateful_eval
-from formulaic.utils.variables import Variable, get_expression_variables
+from formulaic.utils.variables import Variable
 
 from .types import EvaluatedFactor, FactorValues, ScopedFactor, ScopedTerm
 
@@ -596,6 +596,7 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
     def _evaluate(
         self, expr: str, metadata: Any, spec: ModelSpec
     ) -> Tuple[Any, Set[Variable]]:
+        variables: Set[Variable] = set()
         return (
             stateful_eval(
                 expr,
@@ -603,8 +604,9 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
                 {expr: metadata},
                 spec.transform_state,
                 spec,
+                variables=variables,
             ),
-            get_expression_variables(expr, self.layered_context),
+            variables,
         )
 
     def _is_categorical(self, values: Any) -> bool:

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -436,3 +436,12 @@ class TestPandasMaterializer:
         assert mm.model_spec.structure == [
             EncodedTermStructure(term="None", scoped_terms=[], columns=[]),
         ]
+
+    def test_quoted_python_args(self):
+        data = pandas.DataFrame({"exotic!~  -name": [1, 2, 3]})
+        mm = PandasMaterializer(data, output="pandas").get_model_matrix(
+            "np.power(`exotic!~  -name`, 2)"
+        )
+        assert mm.shape == (3, 2)
+        assert len(mm.model_spec.structure) == 2
+        assert numpy.all(mm.values == numpy.array([[1, 1], [1, 4], [1, 9]]))


### PR DESCRIPTION
Adding of the variable tracing broke python argument quoting, apologies to all affected (and thanks for reporting @bashtage).

closes: #151 