### PR TITLE
Improve null handling in `poly` and when generating sparse matrices

### DIFF
--- a/formulaic/utils/null_handling.py
+++ b/formulaic/utils/null_handling.py
@@ -1,0 +1,145 @@
+from functools import singledispatch
+from typing import Any, Sequence, Set, Union
+
+import numpy
+import pandas
+import scipy.sparse as spsparse
+
+from formulaic.materializers.types import FactorValues
+
+
+@singledispatch
+def find_nulls(values: Any) -> Set[int]:
+    """
+    Find the indices of rows in `values` that have null/nan values.
+
+    Args:
+        values: The values in which to find nulls.
+    """
+    raise ValueError(
+        f"No implementation of `find_nulls()` for type `{repr(type(values))}`."
+    )
+
+
+@find_nulls.register
+def _(values: None) -> Set[int]:
+    # Literal `None` values have special meaning and are checked elsewhere.
+    return set()
+
+
+@find_nulls.register
+def _(values: str) -> Set[int]:
+    return set()
+
+
+@find_nulls.register
+def _(values: int) -> Set[int]:
+    return _drop_nulls_scalar(values)
+
+
+@find_nulls.register
+def _(values: float) -> Set[int]:
+    return _drop_nulls_scalar(values)
+
+
+def _drop_nulls_scalar(values: Union[int, float]) -> Set[int]:
+    if isinstance(values, FactorValues):
+        values = values.__wrapped__
+    if numpy.isnan(values):
+        raise ValueError("Constant value is null, invalidating all rows.")
+    return set()
+
+
+@find_nulls.register
+def _(values: list) -> Set[int]:
+    if isinstance(values, FactorValues):
+        # Older versions of pandas (<1.2) cannot unpack this automatically.
+        values = values.__wrapped__
+    return find_nulls(pandas.Series(values))
+
+
+@find_nulls.register
+def _(values: dict) -> Set[int]:
+    indices = set()
+    for vs in values.values():
+        indices.update(find_nulls(vs))
+    return indices
+
+
+@find_nulls.register
+def _(values: pandas.Series) -> Set[int]:
+    return set(numpy.flatnonzero(values.isnull().values))
+
+
+@find_nulls.register
+def _(values: numpy.ndarray) -> Set[int]:
+    if len(values.shape) == 0:
+        if numpy.isnan(values):
+            raise ValueError("Constant value is null, invalidating all rows.")
+        return set()
+
+    if len(values.shape) == 1:
+        return set(numpy.flatnonzero(numpy.isnan(values)))
+
+    if len(values.shape) == 2:
+        return set(numpy.flatnonzero(numpy.any(numpy.isnan(values), axis=1)))
+
+    raise ValueError(
+        "Cannot check for null indices for arrays of more than 2 dimensions."
+    )
+
+
+@find_nulls.register
+def _(values: spsparse.spmatrix) -> Set[int]:
+    rows, _, data = spsparse.find(values)
+    null_data_indices = numpy.flatnonzero(numpy.isnan(data))
+    return set(rows[null_data_indices])
+
+
+@singledispatch
+def drop_rows(values: Any, indices: Sequence[int]) -> Any:
+    """
+    Drop rows corresponding to the given indices in `values`.
+
+    Args:
+        values: The vector from which to drop rows with the given `indices`.
+        indices: The indices of the rows to be dropped.
+    """
+    raise ValueError(
+        f"No implementation of `drop_rows()` for values of type `{repr(type(values))}`."
+    )
+
+
+@drop_rows.register
+def _(values: list, indices: Sequence[int]) -> list:
+    return [value for i, value in enumerate(values) if i not in indices]
+
+
+@drop_rows.register
+def _(values: pandas.Series, indices: Sequence[int]) -> pandas.Series:
+    return values.drop(index=values.index[indices])
+
+
+@drop_rows.register
+def _(values: numpy.ndarray, indices: Sequence[int]) -> numpy.ndarray:
+    return numpy.delete(values, indices, axis=0)
+
+
+@drop_rows.register
+def _(values: spsparse.spmatrix, indices: Sequence[int]) -> numpy.ndarray:
+    """
+    Remove the rows denoted by ``indices`` form the CSR sparse matrix ``mat``.
+    """
+    was_csc = False
+    if isinstance(values, spsparse.csc_matrix):
+        was_csc = True
+        values = values.tocsr()
+    indices = list(indices)
+    mask = numpy.ones(values.shape[0], dtype=bool)
+    mask[indices] = False
+    masked = values[mask]
+
+    if was_csc:
+        masked = masked.tocsc()
+
+    return masked

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -160,11 +160,21 @@ class TestPandasMaterializer:
             )
 
     @pytest.mark.parametrize("formula,tests", PANDAS_TESTS.items())
-    def test_na_handling(self, data_with_nulls, formula, tests):
-        mm = PandasMaterializer(data_with_nulls).get_model_matrix(formula)
-        assert isinstance(mm, pandas.DataFrame)
+    @pytest.mark.parametrize("output", ["pandas", "numpy", "sparse"])
+    def test_na_handling(self, data_with_nulls, formula, tests, output):
+        mm = PandasMaterializer(data_with_nulls).get_model_matrix(
+            formula, output=output
+        )
+        if output == "pandas":
+            assert isinstance(mm, pandas.DataFrame)
+            assert list(mm.columns) == tests[2]
+        elif output == "numpy":
+            assert isinstance(mm, numpy.ndarray)
+
+        else:
+            assert isinstance(mm, spsparse.csc_matrix)
         assert mm.shape == (tests[3], len(tests[2]))
-        assert list(mm.columns) == tests[2]
+        assert list(mm.model_spec.column_names) == tests[2]
 
         if formula == "A:B":
             return

--- a/tests/transforms/test_poly.py
+++ b/tests/transforms/test_poly.py
@@ -153,3 +153,60 @@ class TestPoly:
         assert numpy.allclose(
             poly(data, 3, raw=True), numpy.array([data, data**2, data**3]).T
         )
+
+    def test_nulls(self, data):
+        state = {}
+        data = numpy.concatenate([[numpy.nan, numpy.nan, numpy.nan], data])
+        data[:3] = numpy.nan
+        V = poly(data, degree=3, _state=state)
+
+        assert V.shape[1] == 3
+
+        # Comparison data copied from R output of:
+        # > data = seq(from=0, to=1, by=0.05)
+        # > poly(data, 3)
+        r_reference = numpy.array(
+            [
+                [numpy.nan, numpy.nan, numpy.nan],
+                [numpy.nan, numpy.nan, numpy.nan],
+                [numpy.nan, numpy.nan, numpy.nan],
+                [-3.603750e-01, 0.42285541, -4.332979e-01],
+                [-3.243375e-01, 0.29599879, -1.733191e-01],
+                [-2.883000e-01, 0.18249549, 1.824412e-02],
+                [-2.522625e-01, 0.08234553, 1.489937e-01],
+                [-2.162250e-01, -0.00445111, 2.265312e-01],
+                [-1.801875e-01, -0.07789442, 2.584584e-01],
+                [-1.441500e-01, -0.13798440, 2.523770e-01],
+                [-1.081125e-01, -0.18472105, 2.158888e-01],
+                [-7.207500e-02, -0.21810437, 1.565954e-01],
+                [-3.603750e-02, -0.23813436, 8.209854e-02],
+                [-3.000725e-17, -0.24481103, -4.395626e-17],
+                [3.603750e-02, -0.23813436, -8.209854e-02],
+                [7.207500e-02, -0.21810437, -1.565954e-01],
+                [1.081125e-01, -0.18472105, -2.158888e-01],
+                [1.441500e-01, -0.13798440, -2.523770e-01],
+                [1.801875e-01, -0.07789442, -2.584584e-01],
+                [2.162250e-01, -0.00445111, -2.265312e-01],
+                [2.522625e-01, 0.08234553, -1.489937e-01],
+                [2.883000e-01, 0.18249549, -1.824412e-02],
+                [3.243375e-01, 0.29599879, 1.733191e-01],
+                [3.603750e-01, 0.42285541, 4.332979e-01],
+            ]
+        )
+
+        assert numpy.allclose(
+            V,
+            r_reference,
+            equal_nan=True,
+        )
+
+        assert state["alpha"] == pytest.approx({0: 0.5, 1: 0.5, 2: 0.5})
+        assert state["norms2"] == pytest.approx(
+            {0: 21.0, 1: 1.925, 2: 0.14020416666666669, 3: 0.009734175}
+        )
+
+        assert numpy.allclose(
+            poly(data, degree=3, _state=state),
+            r_reference,
+            equal_nan=True,
+        )

--- a/tests/utils/test_null_handling.py
+++ b/tests/utils/test_null_handling.py
@@ -1,0 +1,78 @@
+import re
+
+import numpy
+import pandas
+import pytest
+import scipy.sparse
+
+from formulaic.materializers.types import FactorValues
+from formulaic.utils.null_handling import find_nulls, drop_rows
+
+
+def test_find_nulls():
+
+    assert find_nulls(None) == set()
+    assert find_nulls(FactorValues(None)) == set()
+    assert find_nulls(1) == set()
+    assert find_nulls(1.0) == set()
+    assert find_nulls("string") == set()
+    assert find_nulls(numpy.array(1)) == set()
+    assert find_nulls([None, 1, 2]) == {0}
+    assert find_nulls({"key": [1, 2, numpy.nan], "key2": [numpy.nan, 1, 0]}) == {0, 2}
+    assert find_nulls(FactorValues([None, 1, 2])) == {0}
+    assert find_nulls(numpy.array([numpy.nan, 1, 2])) == {0}
+    assert find_nulls(numpy.array([[numpy.nan, 1], [0, numpy.nan], [1, 1]])) == {0, 1}
+    assert find_nulls(FactorValues(numpy.array([numpy.nan, 1, 2]))) == {0}
+    assert find_nulls(pandas.Series([None, 1, 2])) == {0}
+    assert find_nulls(FactorValues(pandas.Series([None, 1, 2]))) == {0}
+    assert find_nulls(scipy.sparse.csc_matrix([[numpy.nan], [1], [2]])) == {0}
+    assert find_nulls(
+        FactorValues(scipy.sparse.csc_matrix([[numpy.nan], [1], [2]]))
+    ) == {0}
+
+    with pytest.raises(
+        ValueError, match=re.escape("Constant value is null, invalidating all rows.")
+    ):
+        find_nulls(numpy.nan)
+
+    with pytest.raises(
+        ValueError, match=re.escape("Constant value is null, invalidating all rows.")
+    ):
+        find_nulls(numpy.array(numpy.nan))
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Cannot check for null indices for arrays of more than 2 dimensions."
+        ),
+    ):
+        find_nulls(numpy.array([[[1]]]))
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "No implementation of `find_nulls()` for type `<class 'tuple'>`."
+        ),
+    ):
+        find_nulls((1, 2, 3))
+
+
+def test_drop_rows():
+
+    assert drop_rows([1, 2, 3], [1]) == [1, 3]
+    assert numpy.all(
+        drop_rows(pandas.Series([1, 2, 3]), [0]) == pandas.Series([2, 3], index=[1, 2])
+    )
+    assert numpy.all(drop_rows(numpy.array([1, 2, 3]), [0]) == numpy.array([2, 3]))
+    assert numpy.all(
+        drop_rows(scipy.sparse.csc_matrix([[1, 2], [3, 4]]), [0]).todense()
+        == numpy.array([[3, 4]])
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "No implementation of `drop_rows()` for values of type `<class 'tuple'>`."
+        ),
+    ):
+        drop_rows((1, 2, 3), ())


### PR DESCRIPTION
This patch set greatly improves the generality with which the null data handling works, and should now properly remove null values even in sparse datasets.

It also resolves issues with `poly` whereby `nan` values would propagate in such a way as to make all values `nan`. We now instead maintain the null mask separately, and reapply.

Closes: #150 