### PR TITLE
Do not count literal factors toward degree (fixing sorting of e.g. global intercept).

### DIFF
--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -177,7 +177,7 @@ class Formula(Structured[List[Term]]):
         # Order terms appropriately
         orderer = None
         if self._ordering is OrderingMethod.DEGREE:
-            orderer = lambda terms: sorted(terms, key=lambda term: len(term.factors))
+            orderer = lambda terms: sorted(terms, key=lambda term: term.degree)
         elif self._ordering is OrderingMethod.SORT:
             orderer = lambda terms: sorted(
                 [Term(factors=sorted(term.factors)) for term in terms]

--- a/formulaic/parser/types/term.py
+++ b/formulaic/parser/types/term.py
@@ -14,13 +14,22 @@ class Term:
     a formula is made up of a sum of terms.
 
     Attributes:
-        factors: The set of factors to be multipled to form the term.
+        factors: The set of factors to be multiplied to form the term.
     """
 
     def __init__(self, factors: Iterable["Factor"]):
         self.factors = tuple(dict.fromkeys(factors))
         self._factor_key = tuple(factor.expr for factor in sorted(self.factors))
         self._hash = hash(":".join(self._factor_key))
+
+    @property
+    def degree(self) -> int:
+        """
+        The degree of the `Term`. Literal factors do not contribute to the degree.
+        """
+        return len(
+            tuple(f for f in self.factors if f.eval_method != f.eval_method.LITERAL)
+        )
 
     # Transforms and comparisons
 
@@ -41,9 +50,9 @@ class Term:
 
     def __lt__(self, other: Any) -> bool:
         if isinstance(other, Term):
-            if len(self.factors) == len(other.factors):
+            if self.degree == other.degree:
                 return sorted(self.factors) < sorted(other.factors)
-            if len(self.factors) < len(other.factors):
+            if self.degree < other.degree:
                 return True
             return False
         return NotImplemented

--- a/tests/parser/types/test_term.py
+++ b/tests/parser/types/test_term.py
@@ -42,3 +42,9 @@ class TestTerm:
 
     def test_repr(self, term1):
         assert repr(term1) == "c:b"
+
+    def test_degree(self, term1, term3):
+        assert term1.degree == 2
+        assert term3.degree == 3
+        assert Term([Factor("1", eval_method="literal")]).degree == 0
+        assert Term([Factor("1", eval_method="literal"), Factor("x")]).degree == 1

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -31,10 +31,10 @@ class TestFormula:
     def test_constructor(self):
         assert [str(t) for t in Formula(["a", "b", "c"])] == ["a", "b", "c"]
         assert [str(t) for t in Formula(["a", "c", "b", "1"])] == [
+            "1",
             "a",
             "c",
             "b",
-            "1",
         ]
 
         f = Formula((["a", "b"], ["c", "d"]))


### PR DESCRIPTION
Currently the intercept is considered to be of the same degree as any other single term. This patch causes literal values to not be counted toward a term's degree, which restores the expected behaviour of sorting global intercepts first when ordering of terms is enabled in a formula.

Fixes: #148 