### PR TITLE
Fix transform state not propagating correctly.

### DIFF
--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -186,14 +186,7 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
         # the shared transform state pool.
         model_specs._map(
             lambda ms: ms.transform_state.update(
-                {
-                    factor.expr: factor_evaluation_model_spec.transform_state[
-                        factor.expr
-                    ]
-                    for term in ms.formula
-                    for factor in term.factors
-                    if factor.expr in factor_evaluation_model_spec.transform_state
-                }
+                factor_evaluation_model_spec.transform_state
             )
         )
 

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -472,3 +472,12 @@ class TestPandasMaterializer:
             ),
         ):
             PandasMaterializer(data).get_model_matrix("I(a)")
+
+    def test_transform_state_with_inconsistent_formatting(self, data):
+        ms1 = PandasMaterializer(data).get_model_matrix("bs(a, df=4)").model_spec
+        ms2 = PandasMaterializer(data).get_model_matrix("bs( `a`, df = 4) ").model_spec
+        assert ms1.transform_state == ms2.transform_state
+
+    def test_nested_transform_state(self, data):
+        ms = PandasMaterializer(data).get_model_matrix("bs(bs(a))").model_spec
+        assert {"bs(a)", "bs(bs(a))"}.issubset(ms.transform_state)


### PR DESCRIPTION
When I added support for nested `ModelSpec` computation with a shared factor cache, it broke the storage of transform state for Python factors with different formatting or nested transform states. We now pass through the entire transform state through to all model specs, even if it is superfluous to that model matrix. We can revisit this as an optimisation in the future, since it doesn't hurt to keep extra information.

Closes #165.