### PR TITLE
Added an option to return drop_index

### DIFF
--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -154,11 +154,11 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
     def nrows(self) -> int:
         return len(self.data)
 
-    def get_model_matrix(
+    def get_model_matrix_with_dropped(
         self,
         spec: Union[FormulaSpec, ModelMatrix, ModelMatrices, ModelSpec, ModelSpecs],
         **spec_overrides: Any,
-    ) -> Union[ModelMatrix, ModelMatrices]:
+    ) -> Tuple[Union[ModelMatrix, ModelMatrices], List[int]]:
         from formulaic import ModelSpec
 
         # Prepare ModelSpec(s)
@@ -202,7 +202,20 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
 
         if should_simplify:
             return cast(Union[ModelMatrix, ModelMatrices], model_matrices._simplify())
-        return model_matrices
+        return model_matrices, drop_rows
+
+
+    def get_model_matrix(
+        self,
+        spec: Union[FormulaSpec, ModelMatrix, ModelMatrices, ModelSpec, ModelSpecs],
+        **spec_overrides: Any,
+    ) -> Union[Union[ModelMatrix, ModelMatrices], Tuple[Union[ModelMatrix, ModelMatrices], List[int]]]:
+        return_drop_index = spec_overrides.pop("return_drop_index", False)
+        model_matrices, drop_index = self.get_model_matrix_with_dropped(spec, **spec_overrides)
+        if return_drop_index:
+            return model_matrices, drop_index
+        else:
+            return model_matrices
 
     def _build_model_matrix(
         self, spec: ModelSpec, drop_rows: Sequence[int]

--- a/formulaic/sugar.py
+++ b/formulaic/sugar.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Union, Tuple, List
 
 from .formula import FormulaSpec
 from .model_matrix import ModelMatrices, ModelMatrix
@@ -12,7 +12,7 @@ def model_matrix(
     *,
     context: Union[int, Mapping[str, Any]] = 0,
     **spec_overrides: Any,
-) -> Union[ModelMatrix, ModelMatrices]:
+) -> Union[Union[ModelMatrix, ModelMatrices], Tuple[Union[ModelMatrix, ModelMatrices], List[int]]]:
     """
     Generate a model matrix directly from a formula or model spec.
 
@@ -48,6 +48,8 @@ def model_matrix(
         nominated structure.
     """
     _context = capture_context(context + 1) if isinstance(context, int) else context
+    return_drop_index = spec_overrides.pop("return_drop_index", False)
+
     return ModelSpec.from_spec(spec, **spec_overrides).get_model_matrix(
-        data, context=_context
+        data, context=_context, return_drop_index=return_drop_index
     )


### PR DESCRIPTION
It seems that there is no way currently to retrieve drop_index in case of na_action='drop'
I did minimal work to add this option.
I decided to pass it through kwargs and did special handling of return_drop_index keyword argument through the pipeline.
Another option would be to attach this to ModelSpec(s) itself but that seems dubious and not the right place logically.