### PR TITLE
Add support for passing `drop_rows` in via `*.get_model_matrix()`.

### DIFF
--- a/docsite/docs/guides/missing_data.ipynb
+++ b/docsite/docs/guides/missing_data.ipynb
@@ -1,0 +1,416 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Sooner or later, you will encounter datasets with null values, and it is \n",
+    "important to know how their presence will impact your modeling. Formulaic\n",
+    "model matrix materialization procedures allow you to specify how you want nulls\n",
+    "to be handled. You can either:\n",
+    "\n",
+    "* Automatically drop null rows from the dataset (the default).\n",
+    "* Ignore nulls, and allow them to propagate naturally.\n",
+    "* Raise an exception when null values are encountered.\n",
+    "\n",
+    "You can specify the desired behaviour by passing an `NAAction` enum value (or\n",
+    "string value thereof) to the materialization methods (`model_matrix`, and \n",
+    "`*.get_model_matrix()`). Examples of each of these approaches is show below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dropping null rows (`NAAction.DROP`, or `\"drop\"`)\n",
+    "\n",
+    "This the default behaviour, and will result in any row with a null in any column\n",
+    "that is being used by the materialization being dropped from the resulting \n",
+    "dataset. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Intercept</th>\n",
+       "      <th>c</th>\n",
+       "      <th>C[T.b]</th>\n",
+       "      <th>C[T.c]</th>\n",
+       "      <th>C[T.d]</th>\n",
+       "      <th>C[T.e]</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Intercept    c  C[T.b]  C[T.c]  C[T.d]  C[T.e]\n",
+       "0        1.0  1.0       0       0       0       0\n",
+       "1        1.0  2.0       1       0       0       0\n",
+       "4        1.0  5.0       0       0       0       1"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from formulaic import model_matrix\n",
+    "from formulaic.materializers import NAAction\n",
+    "from pandas import DataFrame, Categorical\n",
+    "\n",
+    "df = DataFrame({\n",
+    "    \"c\": [1, 2, None, 4, 5],\n",
+    "    \"C\": Categorical([\"a\", \"b\", \"c\", None, \"e\"], categories=[\"a\", \"b\", \"c\", \"d\", \"e\"])\n",
+    "})\n",
+    "\n",
+    "model_matrix(\"c + C\", df, na_action=NAAction.DROP)\n",
+    "# Equivlent to:\n",
+    "#   * model_matrix(\"c + C\", df)\n",
+    "#   * model_matrix(\"c + C\", df, na_action=\"drop\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also specify additional rows to drop using the `drop_rows` argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Intercept</th>\n",
+       "      <th>c</th>\n",
+       "      <th>C[T.b]</th>\n",
+       "      <th>C[T.c]</th>\n",
+       "      <th>C[T.d]</th>\n",
+       "      <th>C[T.e]</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Intercept    c  C[T.b]  C[T.c]  C[T.d]  C[T.e]\n",
+       "1        1.0  2.0       1       0       0       0"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_matrix(\"c + C\", df, drop_rows={0, 4})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the set passed to `drop_rows` is expected to be mutable, as it will be\n",
+    "updated with the indices of rows dropped automatically also; which can be useful\n",
+    "if you need to keep track of this information outside of the materialization\n",
+    "procedure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{0, np.int64(2), np.int64(3), 4}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "drop_rows = {0, 4}\n",
+    "model_matrix(\"c + C\", df, drop_rows=drop_rows)\n",
+    "drop_rows"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Ignore nulls (`NAAction.IGNORE`, or `\"ignore\"`)\n",
+    "\n",
+    "If your modeling toolkit can handle the presence of nulls, or you otherwise want\n",
+    "to keep them in the dataset, you can pass `na_action = \"ignore\"` to the \n",
+    "materialization methods. This will allow null values to remain in columns, and \n",
+    "take no action to prevent the propagation of nulls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Intercept</th>\n",
+       "      <th>c</th>\n",
+       "      <th>C[T.b]</th>\n",
+       "      <th>C[T.c]</th>\n",
+       "      <th>C[T.d]</th>\n",
+       "      <th>C[T.e]</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Intercept    c  C[T.b]  C[T.c]  C[T.d]  C[T.e]\n",
+       "0        1.0  1.0       0       0       0       0\n",
+       "1        1.0  2.0       1       0       0       0\n",
+       "2        1.0  NaN       0       1       0       0\n",
+       "3        1.0  4.0       0       0       0       0\n",
+       "4        1.0  5.0       0       0       0       1"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_matrix(\"c + C\", df, na_action=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the `NaN` in the `c` column, and that `NaN` does NOT appear in the dummy\n",
+    "coding of C on row 3, consistent with standard implementations of dummy coding.\n",
+    "This could result in misleading model estimates, so care should be taken.\n",
+    "\n",
+    "You can combine this with `drop_rows`, as described above, to manually filter\n",
+    "out the null values you are concerned about."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Raise for null values (`NAAction.RAISE` or `\"raise\"`)\n",
+    "\n",
+    "If you are unwilling to risk the perils of dropping or ignoring null values, you\n",
+    "can instead opt to raise an exception whenever a null value is found. This can\n",
+    "prevent yourself from accidentally biasing your model, but also makes your code\n",
+    "more brittle. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Error encountered while checking for nulls in `C`: `C` contains null values after evaluation.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    model_matrix(\"c + C\", df, na_action=\"raise\")\n",
+    "except Exception as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As with ignoring nulls above, you can combine this raising behaviour with\n",
+    "`drop_rows` to manually filter out the null values that you feel you can safely\n",
+    "ignore, and then raise if any additional null values make it into your data."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docsite/mkdocs.yml
+++ b/docsite/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - Introduction: guides/index.md
     - Quickstart: guides/quickstart.ipynb
     - How it works: guides/formulae.ipynb
+    - Handling Missing Data: guides/missing_data.ipynb
     - Formula Grammar: guides/grammar.md
     - Model Specs: guides/model_specs.ipynb
     - Transforms: guides/transforms.ipynb

--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -220,6 +220,7 @@ class Formula(Structured[List[Term]]):
         self,
         data: Any,
         context: Optional[Mapping[str, Any]] = None,
+        drop_rows: Optional[Set[int]] = None,
         **spec_overrides: Any,
     ) -> Union[ModelMatrix, Structured[ModelMatrix]]:
         """
@@ -230,13 +231,17 @@ class Formula(Structured[List[Term]]):
             data: The data for which to build the model matrices.
             context: An additional mapping object of names to make available in
                 when evaluating formula term factors.
+            drop_rows: An optional set of row indices to drop from the model
+                matrix. If specified, it will also be updated during
+                materialization with any additional rows dropped due to null
+                values.
             spec_overrides: Any `ModelSpec` attributes to set/override. See
                 `ModelSpec` for more details.
         """
         from .model_spec import ModelSpec
 
         return ModelSpec.from_spec(self, **spec_overrides).get_model_matrix(
-            data, context=context
+            data, context=context, drop_rows=drop_rows
         )
 
     def differentiate(  # pylint: disable=redefined-builtin

--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -157,6 +157,7 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
     def get_model_matrix(
         self,
         spec: Union[FormulaSpec, ModelMatrix, ModelMatrices, ModelSpec, ModelSpecs],
+        drop_rows: Optional[Set[int]] = None,
         **spec_overrides: Any,
     ) -> Union[ModelMatrix, ModelMatrices]:
         from formulaic import ModelSpec
@@ -175,7 +176,7 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
 
         # Step 1: Evaluate all factors and cache the results, keeping track of
         # which rows need dropping (if `self.config.na_action == 'drop'`).
-        drop_rows: Set[int] = set()
+        drop_rows: Set[int] = drop_rows if drop_rows is not None else set()
         for factor in factors:
             self._evaluate_factor(factor, factor_evaluation_model_spec, drop_rows)
         drop_rows: Sequence[int] = sorted(drop_rows)

--- a/formulaic/sugar.py
+++ b/formulaic/sugar.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Union
+from typing import Any, Mapping, Optional, Set, Union
 
 from .formula import FormulaSpec
 from .model_matrix import ModelMatrices, ModelMatrix
@@ -11,6 +11,7 @@ def model_matrix(
     data: Any,
     *,
     context: Union[int, Mapping[str, Any]] = 0,
+    drop_rows: Optional[Set[int]] = None,
     **spec_overrides: Any,
 ) -> Union[ModelMatrix, ModelMatrices]:
     """
@@ -40,6 +41,9 @@ def model_matrix(
             means that all variables in the caller's scope should be made
             accessible when interpreting and evaluating formulae). Otherwise, a
             mapping from variable name to value is expected.
+        drop_rows: An optional set of row indices to drop from the model matrix.
+            If specified, it will also be updated during materialization with
+            any additional rows dropped due to null values.
         spec_overrides: Any `ModelSpec` attributes to set/override. See
             `ModelSpec` for more details.
 
@@ -49,5 +53,5 @@ def model_matrix(
     """
     _context = capture_context(context + 1) if isinstance(context, int) else context
     return ModelSpec.from_spec(spec, **spec_overrides).get_model_matrix(
-        data, context=_context
+        data, context=_context, drop_rows=drop_rows
     )

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -480,3 +480,18 @@ class TestPandasMaterializer:
     def test_nested_transform_state(self, data):
         ms = PandasMaterializer(data).get_model_matrix("bs(bs(a))").model_spec
         assert {"bs(a)", "bs(bs(a))"}.issubset(ms.transform_state)
+
+    def test_drop_rows(self, data, data_with_nulls):
+        drop_rows = {0, 1}
+        mm = PandasMaterializer(data).get_model_matrix("a", drop_rows=drop_rows)
+        assert mm.shape == (1, 2)
+        assert list(mm.index) == [2]
+        assert drop_rows == {0, 1}
+
+        drop_rows = {0, 1}
+        mm = PandasMaterializer(data_with_nulls).get_model_matrix(
+            "a", drop_rows=drop_rows
+        )
+        assert mm.shape == (0, 2)
+        assert not list(mm.index)
+        assert drop_rows == {0, 1, 2}


### PR DESCRIPTION
Example usage:
```
import pandas
from formulaic import model_matrix

df = pandas.DataFrame({"a": [0, None, 1]})
dropped_rows = set()
model_matrix("a", df, drop_rows=dropped_rows)
print(dropped_rows) #  {np.int64(1)}
```

This is an alternative and (I think) simpler approach to exposing the indices of dropped rows, and would supersede #194. Would love your thoughts @andrejmuhic . If this looks fit for purpose, I'll wrap this up and merge in the next few days.

TODO:

- [x] Add unit tests
- [x] Add inline documentation
- [x] Add to docsite

closes: #194, closes: #195