### PR TITLE
Add support for constructing `LinearConstraints` from a list of strings.

### DIFF
--- a/formulaic/utils/constraints.py
+++ b/formulaic/utils/constraints.py
@@ -33,6 +33,7 @@ from formulaic.parser.utils import exc_for_token
 
 LinearConstraintSpec = Union[
     str,
+    List[str],
     Dict[str, Number],
     Tuple["numpy.typing.ArrayLike", "numpy.typing.ArrayLike"],
     "numpy.typing.ArrayLike",
@@ -70,23 +71,31 @@ class LinearConstraints:
                     * str: In which case it is interpreted as a constraints
                         formula (e.g. "x + 2 * y = 3, z + y - x / 10"). All
                         variables used must be present in `variable_names`.
+                    * List[str]: In which case the strings are joined with
+                        commas and expected to look like `str` above.
                     * Dict[str, Number]: In which case each key is treated as
                         formula, and each value as the constraint (e.g. {"x":19}
                         , {"a + b": 0}).
                     * Tuple: a two-tuple describing the constraint matrix and
                         values respectively.
-                    * numpy.ndarray: a constraint matrix (with all values
-                        assumed to be zero).
+                    * numpy.ndarray/numerical sequence: a constraint matrix
+                        (with all values assumed to be zero).
             variable_names: The ordered names of the variables represented by
                 $x$; typically the column names of a `ModelMatrix` instance.
         """
         if isinstance(spec, LinearConstraints):
             return spec
-        if isinstance(spec, (str, dict)):
+        if (
+            isinstance(spec, (str, dict))
+            or isinstance(spec, list)
+            and all(isinstance(s, str) for s in spec)
+        ):
             if variable_names is None:
                 raise ValueError(
                     "`variable_names` must be provided when parsing constraints from a formula."
                 )
+            if isinstance(spec, list):
+                spec = ",".join(spec)
             if isinstance(spec, str):
                 matrix, values = LinearConstraintParser(
                     variable_names=variable_names

--- a/tests/utils/test_constraints.py
+++ b/tests/utils/test_constraints.py
@@ -73,6 +73,12 @@ class TestLinearConstraints:
             (
                 2,
                 LinearConstraints.from_spec(
+                    ["a + b + c - 10", "a - c = 10"], variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                2,
+                LinearConstraints.from_spec(
                     {"a + b + c": 10, "a - c": 10}, variable_names=["a", "b", "c"]
                 ),
             ),


### PR DESCRIPTION
This brings parity with `patsy` in `LinearConstraints`, and allows construction of linear constraints from a list of string specifications; for example:

```
LinearConstraints.from_spec(['a + b = 1', 'a + d = 1'])
```

This is equivalent to:
```
LinearConstraints.from_spec('a + b = 1,a + d = 1')
```

closes: #198 

cc: @bashtage 