### PR TITLE
Add `Formula.required_variables` aid in the external validation of external data.

### DIFF
--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -200,3 +200,10 @@ class TestFormula:
         formula = pickle.load(o)
         assert formula.lhs.root == ["a"]
         assert formula.rhs.root == ["1", "b"]
+
+    def test_required_variables(self):
+        assert Formula("a + b").required_variables == {"a", "b"}
+        assert Formula("a + b + a:b").required_variables == {"a", "b"}
+        assert Formula("a + C(b)").required_variables == {"a", "b"}
+        assert Formula("a + C(b, levels=['b1', 'b2'])").required_variables == {"a", "b"}
+        assert Formula("a + C(b, contr.Treatment)").required_variables == {"a", "b"}


### PR DESCRIPTION
e.g.

```
from formulaic import Formula

f = Formula("apps ~ prior_apps + I(prior_apps**2) + factor + prior_apps:factor")
f.required_variables
# {'apps', 'factor', 'prior_apps'}

f.rhs.required_variables
# {'factor', 'prior_apps'}
```

closes: #179 