### PR TITLE
fix: allow using column names without quotes if parentheses and brackets are balanced.

### DIFF
--- a/formulaic/parser/algos/tokenize.py
+++ b/formulaic/parser/algos/tokenize.py
@@ -88,9 +88,9 @@ def tokenize(
                 yield token
                 token = Token(source=formula)
             continue
-        if quote_context and quote_context[-1] in ('"', "'", "`", ")", "}", "%"):
-            if char in "(`" and quote_context[-1] in "})":
-                quote_context.append(char.replace("(", ")"))
+        if quote_context and quote_context[-1] in ('"', "'", "`", ")", "]", "}", "%"):
+            if char in "`([" and quote_context[-1] in "})]":
+                quote_context.append(char.replace("(", ")").replace("[", "]"))
             token.update(char, i)
             continue
 

--- a/tests/parser/algos/test_tokenize.py
+++ b/tests/parser/algos/test_tokenize.py
@@ -61,6 +61,12 @@ TOKEN_TESTS = {
         "operator:in",
         "operator:custom op",
     ],
+    "A[T.a]": [
+        "python:A[T.a]",
+    ],
+    "A(T.a)": [
+        "python:A(T.a)",
+    ],
 }
 
 TOKEN_ERRORS = {
@@ -68,6 +74,14 @@ TOKEN_ERRORS = {
     "`a": [
         FormulaSyntaxError,
         "Formula ended before quote context was closed. Expected: `",
+    ],
+    "A[(T.a]": [
+        FormulaSyntaxError,
+        r"Formula ended before quote context was closed. Expected: \)",
+    ],
+    "A([T.a)": [
+        FormulaSyntaxError,
+        "Formula ended before quote context was closed. Expected: ]",
     ],
 }
 

--- a/tests/utils/test_constraints.py
+++ b/tests/utils/test_constraints.py
@@ -39,6 +39,12 @@ class TestLinearConstraints:
                     {"a + b + c = 10": -10}, variable_names=["a", "b", "c"]
                 ),
             ),
+            (
+                1,
+                LinearConstraints.from_spec(
+                    {"A[T.a] + b + c = 10": -10}, variable_names=["A[T.a]", "b", "c"]
+                ),
+            ),
             (1, LinearConstraints.from_spec([1, 1, 1], variable_names=["a", "b", "c"])),
             (
                 1,
@@ -86,6 +92,13 @@ class TestLinearConstraints:
                 2,
                 LinearConstraints.from_spec(
                     {"a + b + c = 5": 5, "a - c - 5": 5}, variable_names=["a", "b", "c"]
+                ),
+            ),
+            (
+                2,
+                LinearConstraints.from_spec(
+                    {"A[T.a] + b + c = 5": 5, "A[T.a] - c - 5": 5},
+                    variable_names=["A[T.a]", "b", "c"],
                 ),
             ),
             (


### PR DESCRIPTION
Currently formulaic's tokenizer does not accept square brackets in unquote terms, but does accept parentheses (updating the token to a python term). This patch makes square brackets be interpreted the same as parentheses, allowing unquoted "indexing" of names, and upgrading them to Python tokens. Since this Python does not have to be syntactically valid in some contexts, e.g. in linear constraints, this has the desired behaviour of being able to use column names as the variables names without having to quote the columns. In formulae, this will allow indexing of variables for use as columns, which is also a nice boon.

Quoting will still be required if the parentheses or square brackets are imbalanced. for example: `a[(` will not pass tokenization; but `a[(a)b]` will; even if it is not syntatically valid Python. If this code is actually run, a SyntaxError will be raised at that point.

closes: #211 