### PR TITLE
Improve contrast field formatting.

### DIFF
--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -758,6 +758,7 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
             encoded = FactorValues(
                 encoded.copy(),
                 metadata=encoded.__formulaic_metadata__,  # type: ignore
+                reduced=True,
             )
             del encoded[encoded.__formulaic_metadata__.drop_field]
 
@@ -782,7 +783,7 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
         # Some nested dictionaries may not be a `FactorValues[dict]` instance,
         # in which case we impute the default formatter in `FactorValues.format`.
         if hasattr(values, "__formulaic_metadata__"):
-            name_format = values.__formulaic_metadata__.format
+            name_format = values.__formulaic_metadata__.get_format()
         else:
             name_format = FactorValuesMetadata.format
 

--- a/formulaic/transforms/contrasts.py
+++ b/formulaic/transforms/contrasts.py
@@ -208,6 +208,7 @@ class Contrasts(metaclass=InterfaceMeta):
     INTERFACE_RAISE_ON_VIOLATION = True
 
     FACTOR_FORMAT = "{name}[{field}]"
+    FACTOR_FORMAT_REDUCED = "{name}[{field}]"
 
     def apply(
         self,
@@ -251,9 +252,11 @@ class Contrasts(metaclass=InterfaceMeta):
         if not levels or len(levels) == 1 and reduced_rank:
             if output == "pandas":
                 encoded = pandas.DataFrame(
-                    index=dummies.index
-                    if isinstance(dummies, pandas.DataFrame)
-                    else range(dummies.shape[0])
+                    index=(
+                        dummies.index
+                        if isinstance(dummies, pandas.DataFrame)
+                        else range(dummies.shape[0])
+                    )
                 )
             elif output == "numpy":
                 encoded = numpy.ones((dummies.shape[0], 0))
@@ -269,6 +272,7 @@ class Contrasts(metaclass=InterfaceMeta):
                 column_names=cast(Tuple[Hashable], ()),
                 spans_intercept=False,
                 format=self.get_factor_format(levels, reduced_rank=reduced_rank),
+                format_reduced=self.get_factor_format(levels, reduced_rank=True),
                 encoded=True,
             )
 
@@ -295,6 +299,7 @@ class Contrasts(metaclass=InterfaceMeta):
             spans_intercept=self.get_spans_intercept(levels, reduced_rank=reduced_rank),
             drop_field=self.get_drop_field(levels, reduced_rank=reduced_rank),
             format=self.get_factor_format(levels, reduced_rank=reduced_rank),
+            format_reduced=self.get_factor_format(levels, reduced_rank=True),
             encoded=True,
         )
 
@@ -480,7 +485,7 @@ class Contrasts(metaclass=InterfaceMeta):
             levels: The names of the levels/categories in the data.
             reduced_rank: Whether the contrast encoding used had reduced rank.
         """
-        return self.FACTOR_FORMAT
+        return self.FACTOR_FORMAT_REDUCED if reduced_rank else self.FACTOR_FORMAT
 
 
 @dataclass
@@ -493,7 +498,7 @@ class TreatmentContrasts(Contrasts):
     is taken to be the first level.
     """
 
-    FACTOR_FORMAT = "{name}[T.{field}]"
+    FACTOR_FORMAT_REDUCED = "{name}[T.{field}]"
 
     base: Hashable = UNSET
 
@@ -609,7 +614,7 @@ class SumContrasts(Contrasts):
     (except the last, which is redundant) to the global average of all levels.
     """
 
-    FACTOR_FORMAT = "{name}[S.{field}]"
+    FACTOR_FORMAT_REDUCED = "{name}[S.{field}]"
 
     @Contrasts.override
     def _get_coding_matrix(
@@ -659,7 +664,7 @@ class HelmertContrasts(Contrasts):
             integer one).
     """
 
-    FACTOR_FORMAT = "{name}[H.{field}]"
+    FACTOR_FORMAT_REDUCED = "{name}[H.{field}]"
 
     reverse: bool = True
     scale: bool = False
@@ -729,7 +734,7 @@ class DiffContrasts(Contrasts):
             Level 1 cf. Level 1 - Level 2).
     """
 
-    FACTOR_FORMAT = "{name}[D.{field}]"
+    FACTOR_FORMAT_REDUCED = "{name}[D.{field}]"
 
     backward: bool = True
 
@@ -792,7 +797,6 @@ class PolyContrasts(Contrasts):
             have the same cardinality as the categories being coded.
     """
 
-    FACTOR_FORMAT = "{name}{field}"
     NAME_ALIASES = {
         1: ".L",
         2: ".Q",

--- a/tests/materializers/test_arrow.py
+++ b/tests/materializers/test_arrow.py
@@ -19,15 +19,15 @@ ARROW_TESTS = {
     "a": (["Intercept", "a"], ["Intercept", "a"]),
     "A": (
         ["Intercept", "A[T.b]", "A[T.c]"],
-        ["Intercept", "A[T.a]", "A[T.b]", "A[T.c]"],
+        ["Intercept", "A[a]", "A[b]", "A[c]"],
     ),
     "C(A)": (
         ["Intercept", "C(A)[T.b]", "C(A)[T.c]"],
-        ["Intercept", "C(A)[T.a]", "C(A)[T.b]", "C(A)[T.c]"],
+        ["Intercept", "C(A)[a]", "C(A)[b]", "C(A)[c]"],
     ),
     "a:A": (
-        ["Intercept", "a:A[T.a]", "a:A[T.b]", "a:A[T.c]"],
-        ["Intercept", "a:A[T.a]", "a:A[T.b]", "a:A[T.c]"],
+        ["Intercept", "a:A[a]", "a:A[b]", "a:A[c]"],
+        ["Intercept", "a:A[a]", "a:A[b]", "a:A[c]"],
     ),
 }
 

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -24,20 +24,20 @@ PANDAS_TESTS = {
     "a": (["Intercept", "a"], ["Intercept", "a"], ["Intercept", "a"], 2),
     "A": (
         ["Intercept", "A[T.b]", "A[T.c]"],
-        ["Intercept", "A[T.a]", "A[T.b]", "A[T.c]"],
+        ["Intercept", "A[a]", "A[b]", "A[c]"],
         ["Intercept", "A[T.c]"],
         2,
     ),
     "C(A)": (
         ["Intercept", "C(A)[T.b]", "C(A)[T.c]"],
-        ["Intercept", "C(A)[T.a]", "C(A)[T.b]", "C(A)[T.c]"],
+        ["Intercept", "C(A)[a]", "C(A)[b]", "C(A)[c]"],
         ["Intercept", "C(A)[T.c]"],
         2,
     ),
     "A:a": (
-        ["Intercept", "A[T.a]:a", "A[T.b]:a", "A[T.c]:a"],
-        ["Intercept", "A[T.a]:a", "A[T.b]:a", "A[T.c]:a"],
-        ["Intercept", "A[T.a]:a"],
+        ["Intercept", "A[a]:a", "A[b]:a", "A[c]:a"],
+        ["Intercept", "A[a]:a", "A[b]:a", "A[c]:a"],
+        ["Intercept", "A[a]:a"],
         1,
     ),
     "A:B": (
@@ -45,24 +45,24 @@ PANDAS_TESTS = {
             "Intercept",
             "B[T.b]",
             "B[T.c]",
-            "A[T.b]:B[T.a]",
-            "A[T.c]:B[T.a]",
-            "A[T.b]:B[T.b]",
-            "A[T.c]:B[T.b]",
-            "A[T.b]:B[T.c]",
-            "A[T.c]:B[T.c]",
+            "A[T.b]:B[a]",
+            "A[T.c]:B[a]",
+            "A[T.b]:B[b]",
+            "A[T.c]:B[b]",
+            "A[T.b]:B[c]",
+            "A[T.c]:B[c]",
         ],
         [
             "Intercept",
-            "A[T.a]:B[T.a]",
-            "A[T.b]:B[T.a]",
-            "A[T.c]:B[T.a]",
-            "A[T.a]:B[T.b]",
-            "A[T.b]:B[T.b]",
-            "A[T.c]:B[T.b]",
-            "A[T.a]:B[T.c]",
-            "A[T.b]:B[T.c]",
-            "A[T.c]:B[T.c]",
+            "A[a]:B[a]",
+            "A[b]:B[a]",
+            "A[c]:B[a]",
+            "A[a]:B[b]",
+            "A[b]:B[b]",
+            "A[c]:B[b]",
+            "A[a]:B[c]",
+            "A[b]:B[c]",
+            "A[c]:B[c]",
         ],
         ["Intercept"],
         1,
@@ -324,7 +324,7 @@ class TestPandasMaterializer:
                 spec=ModelSpec(formula=[]),
                 drop_rows=[],
             )
-        ) == ["B[a][T.a]", "B[a][T.b]", "B[a][T.c]"]
+        ) == ["B[a][a]", "B[a][b]", "B[a][c]"]
 
     def test_empty(self, materializer):
         mm = materializer.get_model_matrix("0", ensure_full_rank=True)
@@ -366,27 +366,27 @@ class TestPandasMaterializer:
         )
 
         m = PandasMaterializer(data).get_model_matrix("A + 0", ensure_full_rank=False)
-        assert list(m.columns) == ["A[T.a]", "A[T.b]", "A[T.c]"]
+        assert list(m.columns) == ["A[a]", "A[b]", "A[c]"]
         assert list(m.model_spec.get_model_matrix(data3).columns) == [
-            "A[T.a]",
-            "A[T.b]",
-            "A[T.c]",
+            "A[a]",
+            "A[b]",
+            "A[c]",
         ]
 
         m2 = PandasMaterializer(data2).get_model_matrix("A + 0", ensure_full_rank=False)
-        assert list(m2.columns) == ["A[T.a]", "A[T.b]", "A[T.c]"]
+        assert list(m2.columns) == ["A[a]", "A[b]", "A[c]"]
         assert list(m2.model_spec.get_model_matrix(data3).columns) == [
-            "A[T.a]",
-            "A[T.b]",
-            "A[T.c]",
+            "A[a]",
+            "A[b]",
+            "A[c]",
         ]
 
         m3 = PandasMaterializer(data3).get_model_matrix("A + 0", ensure_full_rank=False)
-        assert list(m3.columns) == ["A[T.c]", "A[T.b]", "A[T.a]"]
+        assert list(m3.columns) == ["A[c]", "A[b]", "A[a]"]
         assert list(m3.model_spec.get_model_matrix(data).columns) == [
-            "A[T.c]",
-            "A[T.b]",
-            "A[T.a]",
+            "A[c]",
+            "A[b]",
+            "A[a]",
         ]
 
     def test_term_clustering(self, materializer):

--- a/tests/transforms/test_contrasts.py
+++ b/tests/transforms/test_contrasts.py
@@ -61,7 +61,8 @@ class TestContrastsTransform:
                 spans_intercept=True,
                 column_names=("a", "b", "c"),
                 drop_field="a",
-                format="{name}[T.{field}]",
+                format="{name}[{field}]",
+                format_reduced="{name}[T.{field}]",
                 encoded=True,
             ),
         )
@@ -87,7 +88,8 @@ class TestContrastsTransform:
                     spans_intercept=True,
                     column_names=("a", "b", "c"),
                     drop_field="a",
-                    format="{name}[T.{field}]",
+                    format="{name}[{field}]",
+                    format_reduced="{name}[T.{field}]",
                     encoded=True,
                 ),
             )
@@ -113,6 +115,7 @@ class TestContrastsTransform:
                 column_names=("b", "c"),
                 drop_field=None,
                 format="{name}[T.{field}]",
+                format_reduced="{name}[T.{field}]",
                 encoded=True,
             ),
         )
@@ -140,7 +143,8 @@ class TestContrastsTransform:
                 spans_intercept=True,
                 column_names=("a", "b", "c"),
                 drop_field="a",
-                format="{name}[T.{field}]",
+                format="{name}[{field}]",
+                format_reduced="{name}[T.{field}]",
                 encoded=True,
             ),
         )
@@ -166,6 +170,7 @@ class TestContrastsTransform:
                 column_names=("b", "c"),
                 drop_field=None,
                 format="{name}[T.{field}]",
+                format_reduced="{name}[T.{field}]",
                 encoded=True,
             ),
         )
@@ -191,7 +196,8 @@ class TestContrastsTransform:
                     spans_intercept=True,
                     column_names=("a", "b", "c"),
                     drop_field="a",
-                    format="{name}[T.{field}]",
+                    format="{name}[{field}]",
+                    format_reduced="{name}[T.{field}]",
                     encoded=True,
                 ),
             )
@@ -226,7 +232,8 @@ class TestContrastsTransform:
                 spans_intercept=True,
                 column_names=("a", "b", "c"),
                 drop_field="c",
-                format="{name}[T.{field}]",
+                format="{name}[{field}]",
+                format_reduced="{name}[T.{field}]",
                 encoded=True,
             ),
         )
@@ -253,7 +260,8 @@ class TestContrastsTransform:
                 spans_intercept=True,
                 column_names=("a", "b", "c"),
                 drop_field="a",
-                format="{name}[T.{field}]",
+                format="{name}[{field}]",
+                format_reduced="{name}[T.{field}]",
                 encoded=True,
             ),
         )
@@ -279,6 +287,7 @@ class TestContrastsTransform:
                 column_names=("ordinal",),
                 drop_field=None,
                 format="{name}[{field}]",
+                format_reduced="{name}[{field}]",
                 encoded=True,
             ),
         )
@@ -347,6 +356,7 @@ class TestTreatmentContrasts:
         encoded = contrasts.apply(category_dummies, ["a", "b", "c"])
         assert list(encoded.columns) == ["b", "c"]
         assert encoded.__formulaic_metadata__.drop_field is None
+        assert encoded.__formulaic_metadata__.format == "{name}[T.{field}]"
         assert encoded.to_dict("list") == {
             "b": [0, 1, 0, 0, 1, 0],
             "c": [0, 0, 1, 0, 0, 1],
@@ -357,6 +367,7 @@ class TestTreatmentContrasts:
         )
         assert list(encoded_spanning.columns) == ["a", "b", "c"]
         assert encoded_spanning.__formulaic_metadata__.drop_field == "a"
+        assert encoded_spanning.__formulaic_metadata__.format == "{name}[{field}]"
         assert encoded_spanning.to_dict("list") == {
             "a": [1, 0, 0, 1, 0, 0],
             "b": [0, 1, 0, 0, 1, 0],
@@ -605,6 +616,16 @@ class TestSumContrasts:
         assert SumContrasts().get_drop_field(["a", "b", "c"]) is None
         assert SumContrasts().get_drop_field(["a", "b", "c"], reduced_rank=False) == "a"
 
+    def test_get_factor_format(self):
+        assert (
+            SumContrasts().get_factor_format(None, reduced_rank=False)
+            == "{name}[{field}]"
+        )
+        assert (
+            SumContrasts().get_factor_format(None, reduced_rank=True)
+            == "{name}[S.{field}]"
+        )
+
 
 class TestHelmertContrasts:
     def test_coding_matrix(self):
@@ -691,6 +712,16 @@ class TestHelmertContrasts:
         )
         assert numpy.allclose(coefficient_matrix_reduced, reference_reduced)
 
+    def test_get_factor_format(self):
+        assert (
+            contr.helmert().get_factor_format(None, reduced_rank=False)
+            == "{name}[{field}]"
+        )
+        assert (
+            contr.helmert().get_factor_format(None, reduced_rank=True)
+            == "{name}[H.{field}]"
+        )
+
 
 class TestDiffContrasts:
     def test_coding_matrix(self):
@@ -764,6 +795,16 @@ class TestDiffContrasts:
             ["a", "b", "c"], reduced_rank=True
         )
         assert numpy.allclose(coefficient_matrix_reduced, reference_reduced)
+
+    def test_get_factor_format(self):
+        assert (
+            contr.diff().get_factor_format(None, reduced_rank=False)
+            == "{name}[{field}]"
+        )
+        assert (
+            contr.diff().get_factor_format(None, reduced_rank=True)
+            == "{name}[D.{field}]"
+        )
 
 
 class TestPolyContrasts:
@@ -847,6 +888,15 @@ class TestPolyContrasts:
         )
         assert numpy.allclose(coefficient_matrix_reduced, reference_reduced)
 
+    def test_get_factor_format(self):
+        assert (
+            contr.poly().get_factor_format(None, reduced_rank=False)
+            == "{name}[{field}]"
+        )
+        assert (
+            contr.poly().get_factor_format(None, reduced_rank=True) == "{name}[{field}]"
+        )
+
 
 class TestCustomContrasts:
     def test_coding_matrix(self):
@@ -928,9 +978,9 @@ def test_full_rankness_opt_out():
         "C(A, spans_intercept=False)", data
     ).model_spec.column_names == (
         "Intercept",
-        "C(A, spans_intercept=False)[T.a]",
-        "C(A, spans_intercept=False)[T.b]",
-        "C(A, spans_intercept=False)[T.c]",
+        "C(A, spans_intercept=False)[a]",
+        "C(A, spans_intercept=False)[b]",
+        "C(A, spans_intercept=False)[c]",
     )
 
 


### PR DESCRIPTION
Only prefix categorical fields with `T.` (etc) when they actually describe contrasts (i.e. when they are encoded with reduced rank).

Fixes inconsistency with `patsy` described [here](https://github.com/matthewwardrop/formulaic/pull/213#issuecomment-2506277959). This behaviour makes more semantic sense than the current blanket formatting, and so let's adopt it here too.

cc: @bashtage 