### PR TITLE
basis_spline: Fix evaluation involving `nan` values and disallow knots outside of bounds.

### DIFF
--- a/formulaic/transforms/basis_spline.py
+++ b/formulaic/transforms/basis_spline.py
@@ -98,6 +98,9 @@ def basis_spline(  # pylint: disable=dangerous-default-value  # always replaced 
     if df is not None and knots is not None:
         raise ValueError("You cannot specify both `df` and `knots`.")
 
+    # Ensure ndarray to avoid conversion overhead
+    x = numpy.asarray(x)
+
     if "lower_bound" in _state:
         lower_bound = float(_state["lower_bound"])
     else:
@@ -115,7 +118,6 @@ def basis_spline(  # pylint: disable=dangerous-default-value  # always replaced 
     extrapolation = SplineExtrapolation(extrapolation)
 
     # Prepare data
-    x = numpy.asarray(x)
     if extrapolation is SplineExtrapolation.RAISE and numpy.any(
         (x < lower_bound) | (x > upper_bound)
     ):

--- a/formulaic/transforms/basis_spline.py
+++ b/formulaic/transforms/basis_spline.py
@@ -98,22 +98,21 @@ def basis_spline(  # pylint: disable=dangerous-default-value  # always replaced 
     if df is not None and knots is not None:
         raise ValueError("You cannot specify both `df` and `knots`.")
 
-    # Ensure ndarray to avoid conversion overhead
     x = numpy.asarray(x)
 
     if "lower_bound" in _state:
         lower_bound = float(_state["lower_bound"])
+    elif lower_bound is not None:
+        _state["lower_bound"] = lower_bound
     else:
-        lower_bound = _state["lower_bound"] = (
-            float(numpy.nanmin(x)) if lower_bound is None else float(lower_bound)
-        )
+        _state["lower_bound"] = lower_bound = float(numpy.nanmin(x))
 
     if "upper_bound" in _state:
         upper_bound = float(_state["upper_bound"])
+    elif upper_bound is not None:
+        _state["upper_bound"] = upper_bound
     else:
-        upper_bound = _state["upper_bound"] = (
-            float(numpy.nanmax(x)) if upper_bound is None else float(upper_bound)
-        )
+        _state["upper_bound"] = upper_bound = float(numpy.nanmax(x))
 
     extrapolation = SplineExtrapolation(extrapolation)
 
@@ -130,13 +129,17 @@ def basis_spline(  # pylint: disable=dangerous-default-value  # always replaced 
         SplineExtrapolation.NA,
         SplineExtrapolation.ZERO,
     ):
-        valid_x = (x >= lower_bound) & (x <= upper_bound)
-        if extrapolation is SplineExtrapolation.CLIP:
-            x = numpy.clip(x, lower_bound, upper_bound)
-        elif extrapolation is SplineExtrapolation.NA:
-            x = numpy.where((x >= lower_bound) & (x <= upper_bound), x, numpy.nan)
+        locs = (x >= lower_bound) & (x <= upper_bound)
+        if not numpy.all(locs):
+            knots_x = x[locs]
+            if extrapolation is SplineExtrapolation.CLIP:
+                x = numpy.clip(x, lower_bound, upper_bound)
+            elif extrapolation is SplineExtrapolation.NA:
+                x = numpy.where(locs, x, numpy.nan)
+        else:
+            knots_x = x
     else:
-        valid_x = numpy.ones_like(x, dtype=bool)
+        knots_x = x
 
     # Prepare knots
     if "knots" not in _state:
@@ -147,13 +150,13 @@ def basis_spline(  # pylint: disable=dangerous-default-value  # always replaced 
                 raise ValueError(
                     f"Invalid value for `df`. `df` must be greater than {degree + (1 if include_intercept else 0)} [`degree` (+ 1 if `include_intercept` is `True`)]."
                 )
-            if valid_x.sum(0) < nknots:
+            if knots_x.shape[0] < nknots:
                 raise ValueError(
                     f"Insufficient valid data points to compute {nknots} knots."
                 )
             knots = cast(
                 List[float],
-                numpy.nanquantile(x[valid_x], numpy.linspace(0, 1, nknots + 2))[
+                numpy.nanquantile(knots_x, numpy.linspace(0, 1, nknots + 2))[
                     1:-1
                 ].tolist(),
             )

--- a/formulaic/transforms/basis_spline.py
+++ b/formulaic/transforms/basis_spline.py
@@ -99,22 +99,24 @@ def basis_spline(  # pylint: disable=dangerous-default-value  # always replaced 
         raise ValueError("You cannot specify both `df` and `knots`.")
 
     if "lower_bound" in _state:
-        lower_bound = _state["lower_bound"]
+        lower_bound = float(_state["lower_bound"])
     else:
         lower_bound = _state["lower_bound"] = (
-            numpy.min(x) if lower_bound is None else lower_bound
+            float(numpy.nanmin(x)) if lower_bound is None else float(lower_bound)
         )
 
     if "upper_bound" in _state:
-        upper_bound = _state["upper_bound"]
+        upper_bound = float(_state["upper_bound"])
     else:
         upper_bound = _state["upper_bound"] = (
-            numpy.max(x) if upper_bound is None else upper_bound
+            float(numpy.nanmax(x)) if upper_bound is None else float(upper_bound)
         )
 
     extrapolation = SplineExtrapolation(extrapolation)
 
     # Prepare data
+    if not isinstance(x, (numpy.ndarray, pandas.Series)):
+        x = numpy.array(x)
     if extrapolation is SplineExtrapolation.RAISE and numpy.any(
         (x < lower_bound) | (x > upper_bound)
     ):
@@ -141,7 +143,7 @@ def basis_spline(  # pylint: disable=dangerous-default-value  # always replaced 
             )
         knots.insert(0, cast(float, lower_bound))
         knots.append(cast(float, upper_bound))
-        knots = list(numpy.pad(knots, degree, mode="edge"))
+        knots = numpy.pad(knots, degree, mode="edge").tolist()
         _state["knots"] = knots
     knots = _state["knots"]
 

--- a/formulaic/transforms/basis_spline.py
+++ b/formulaic/transforms/basis_spline.py
@@ -150,9 +150,11 @@ def basis_spline(  # pylint: disable=dangerous-default-value  # always replaced 
                 raise ValueError(
                     f"Invalid value for `df`. `df` must be greater than {degree + (1 if include_intercept else 0)} [`degree` (+ 1 if `include_intercept` is `True`)]."
                 )
-            if knots_x.shape[0] < nknots:
+            if knots_x.shape[0] == 0:
                 raise ValueError(
-                    f"Insufficient valid data points to compute {nknots} knots."
+                    "After adjusting the sample using extrapolation="
+                    f"{extrapolation.value} with bounds ({lower_bound}, "
+                    f"{upper_bound}), no data points are available for knot selection."
                 )
             knots = cast(
                 List[float],

--- a/tests/transforms/test_basis_spline.py
+++ b/tests/transforms/test_basis_spline.py
@@ -534,3 +534,16 @@ class TestBasisSpline:
                 numpy.testing.assert_allclose(
                     res[key][out_of_range], reference, atol=1e-14
                 )
+
+    @pytest.mark.parametrize("extrapolation", ["na", "zero"])
+    def test_basis_spline_all_out_of_bounds(self, data, extrapolation):
+        state = {}
+        with pytest.raises(ValueError, match="After adjusting the sample"):
+            basis_spline(
+                data,
+                df=3,
+                lower_bound=0.56,
+                upper_bound=0.59,
+                extrapolation=extrapolation,
+                _state=state,
+            )

--- a/tests/transforms/test_basis_spline.py
+++ b/tests/transforms/test_basis_spline.py
@@ -1,6 +1,7 @@
 import re
 
 import numpy
+import pandas as pd
 import pytest
 
 from formulaic import model_matrix
@@ -510,3 +511,26 @@ class TestBasisSpline:
             ),
         ):
             basis_spline([-2, 2], extrapolation="raise", _state=state)
+
+    @pytest.mark.parametrize("extrapolation", ["na", "zero"])
+    @pytest.mark.parametrize("bounds", [[0.0, 1.0], [0.25, 0.75]])
+    def test_extrapolation_zero(self, extrapolation, bounds):
+        data = numpy.linspace(0, 1, 77)
+        state = {}
+        lower, upper = bounds
+        res = basis_spline(
+            data,
+            df=7,
+            lower_bound=lower,
+            upper_bound=upper,
+            extrapolation=extrapolation,
+            _state=state,
+        )
+        out_of_range = (data < lower) | (data > upper)
+        if numpy.any(out_of_range):
+            val = 0.0 if extrapolation == "zero" else numpy.nan
+            reference = numpy.full(out_of_range.sum(), val)
+            for key in res:
+                numpy.testing.assert_allclose(
+                    res[key][out_of_range], reference, atol=1e-14
+                )


### PR DESCRIPTION
Use nan-functions to handle nan in input vectors as well as NA extrapolation Add test that demonstrates the issue with ZERO extrapolation