### PR TITLE
Add explicit classes for structured and unstructured formula variants.

### DIFF
--- a/docsite/docs/guides/formulae.ipynb
+++ b/docsite/docs/guides/formulae.ipynb
@@ -38,7 +38,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Formulas in Formulaic are represented by the `Formula` class. Instances of `Formula` are a container for a set of `Term` instances, which in turn are a container for a set of `Factor` instances. Let's start our dissection at the bottom, and work our way up."
+    "Formulas in Formulaic are represented by (subclasses of) the `Formula` class. Instances of `Formula` subclasses are a ultimately containers for sets of `Term` instances, which in turn are a container for a set of `Factor` instances. Let's start our dissection at the bottom, and work our way up."
    ]
   },
   {
@@ -147,9 +147,9 @@
    "source": [
     "### Formula\n",
     "\n",
-    "`Formula` instances are wrappers around collections of `Term` instances. During\n",
-    "materialization into a model matrix, each `Term` instance will have its columns\n",
-    "independently inserted into the resulting matrix.\n",
+    "`Formula` instances are (potentially nested) wrappers around collections of\n",
+    "`Term` instances. During materialization into a model matrix, each `Term`\n",
+    "instance will have its columns independently inserted into the resulting matrix.\n",
     "\n",
     "`Formula` instances can consist of a single \"list\" of `Term` instances, or may\n",
     "be \"structured\"; for example, we may want a separate collection of terms for the\n",
@@ -190,17 +190,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that, the terms are separated by \"+\" which is interpreted as the set union\n",
-    "in this context, and that (as we have seen for `Term` instances) `Formula`\n",
-    "instances are sorted to ensure that equivalent formulas are uniquely\n",
-    "represented.\n",
+    "Note that unstructured formulae are actually instances of `SimpleFormula` (a `Formula` subclass that acts like a mutable list of `Term` instances):\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(formulaic.formula.SimpleFormula, [a:b, c:d:e])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(_), list(_)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also note that in its standard representation, the terms are separated by \"+\"\n",
+    "which is interpreted as the set union in this context, and that (as we have seen\n",
+    "for `Term` instances) `Formula` instances are sorted (the default is to sort \n",
+    "terms only by interaction order, but this can be customized and/or disabled, as\n",
+    "described below).\n",
     "\n",
     "Structured formula are constructed similary:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -217,7 +245,7 @@
        "        really_nested_col"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -244,6 +272,33 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Structured formulae are instances of `StructuredFormula`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "formulaic.formula.StructuredFormula"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(_)"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -253,16 +308,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[root_col]"
+       "root_col"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -285,7 +340,7 @@
        "    really_nested_col"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -304,13 +359,14 @@
     "sorted by their interaction degree (number of factors) and then by the order in\n",
     "which they were present in the the term list. This behaviour can be modified to\n",
     "perform no ordering or full lexical sorting of terms and factors by passing\n",
-    "`_ordering=\"none\"` or `_ordering=\"sort\"` to the `Formula` constructor. The\n",
-    "default ordering is equivalent to passing `_ordering=\"degree\"`. For example:"
+    "`_ordering=\"none\"` or `_ordering=\"sort\"` respectively to the `Formula`\n",
+    "constructor. The default ordering is equivalent to passing `_ordering=\"degree\"`.\n",
+    "For example:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -321,7 +377,7 @@
        " 'sort': 1 + g + z + a:z + a:b:z}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -398,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -417,7 +473,7 @@
        " 'e + f : python']"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -465,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -474,7 +530,7 @@
        "<ASTNode ~: [y, <ASTNode +: [<ASTNode +: [1, a]>, <ASTNode :: [b, c]>]>]>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -502,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -514,7 +570,7 @@
        "    {a, b:c}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -526,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -538,7 +594,7 @@
        "    a + b:c"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -562,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -574,7 +630,7 @@
        "    a + b:c"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -600,132 +656,6 @@
     "Once you have `Formula` instance, the next logical step is to use it to\n",
     "materialize a model matrix. This is usually as simple passing the raw data as\n",
     "an argument to `.get_model_matrix()`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Intercept</th>\n",
-       "      <th>a</th>\n",
-       "      <th>b:c</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1.0</td>\n",
-       "      <td>2</td>\n",
-       "      <td>40</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1.0</td>\n",
-       "      <td>3</td>\n",
-       "      <td>54</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Intercept  a  b:c\n",
-       "0        1.0  1   28\n",
-       "1        1.0  2   40\n",
-       "2        1.0  3   54"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import pandas\n",
-    "\n",
-    "data = pandas.DataFrame({\"a\": [1,2,3], \"b\": [4,5,6], \"c\": [7, 8, 9], \"A\": [\"a\", \"b\", \"c\"]})\n",
-    "Formula(\"a + b:c\").get_model_matrix(data)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Just as for formulae, the model matrices can be structured, and will be structured\n",
-    "in the same way as the original formula. For example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "root:\n",
-       "       Intercept  a\n",
-       "    0        1.0  1\n",
-       "    1        1.0  2\n",
-       "    2        1.0  3\n",
-       ".group:\n",
-       "       b  c\n",
-       "    0  4  7\n",
-       "    1  5  8\n",
-       "    2  6  9"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Formula(\"a\", group=\"b+c\").get_model_matrix(data)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Under the hood, both of these calls have looked at the type of the data\n",
-    "(`pandas.DataFrame` here) and then looked up the `FormulaMaterializer` \n",
-    "associated with that type (`PandasMaterializer` here), and then passed the \n",
-    "formula and data along to the materializer for materialization. It is also \n",
-    "possible to request a specific output type that varies by materializer \n",
-    "(`PandasMaterializer` supports \"pandas\", \"numpy\", and \"sparse\"). If one is not \n",
-    "selected, the first available output type is selected for you. Thus, the above\n",
-    "code is equivalent to:"
    ]
   },
   {
@@ -795,6 +725,132 @@
     }
    ],
    "source": [
+    "import pandas\n",
+    "\n",
+    "data = pandas.DataFrame({\"a\": [1,2,3], \"b\": [4,5,6], \"c\": [7, 8, 9], \"A\": [\"a\", \"b\", \"c\"]})\n",
+    "Formula(\"a + b:c\").get_model_matrix(data)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just as for formulae, the model matrices can be structured, and will be structured\n",
+    "in the same way as the original formula. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "root:\n",
+       "       Intercept  a\n",
+       "    0        1.0  1\n",
+       "    1        1.0  2\n",
+       "    2        1.0  3\n",
+       ".group:\n",
+       "       b  c\n",
+       "    0  4  7\n",
+       "    1  5  8\n",
+       "    2  6  9"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Formula(\"a\", group=\"b+c\").get_model_matrix(data)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Under the hood, both of these calls have looked at the type of the data\n",
+    "(`pandas.DataFrame` here) and then looked up the `FormulaMaterializer` \n",
+    "associated with that type (`PandasMaterializer` here), and then passed the \n",
+    "formula and data along to the materializer for materialization. It is also \n",
+    "possible to request a specific output type that varies by materializer \n",
+    "(`PandasMaterializer` supports \"pandas\", \"numpy\", and \"sparse\"). If one is not \n",
+    "selected, the first available output type is selected for you. Thus, the above\n",
+    "code is equivalent to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Intercept</th>\n",
+       "      <th>a</th>\n",
+       "      <th>b:c</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>3</td>\n",
+       "      <td>54</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Intercept  a  b:c\n",
+       "0        1.0  1   28\n",
+       "1        1.0  2   40\n",
+       "2        1.0  3   54"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "from formulaic.materializers import PandasMaterializer\n",
     "PandasMaterializer(data).get_model_matrix(Formula(\"a + b:c\"), output=\"pandas\")"
    ]
@@ -813,7 +869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -822,7 +878,7 @@
        "(True, True)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -852,7 +908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -861,7 +917,7 @@
        "ModelSpec(formula=1 + a + b:c, materializer='pandas', materializer_params={}, ensure_full_rank=True, na_action=<NAAction.DROP: 'drop'>, output='numpy', cluster_by=<ClusterBy.NONE: 'none'>, structure=[EncodedTermStructure(term=1, scoped_terms=[1], columns=['Intercept']), EncodedTermStructure(term=a, scoped_terms=[a], columns=['a']), EncodedTermStructure(term=b:c, scoped_terms=[b:c], columns=['b:c'])], transform_state={}, encoder_state={'a': (<Kind.NUMERICAL: 'numerical'>, {}), 'b': (<Kind.NUMERICAL: 'numerical'>, {}), 'c': (<Kind.NUMERICAL: 'numerical'>, {})})"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -887,7 +943,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -962,7 +1018,7 @@
        "2        1.0  3         0         3  6         0         6"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -974,7 +1030,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -988,14 +1044,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.12.5"
   },
-  "orig_nbformat": 4,
-  "vscode": {
-   "interpreter": {
-    "hash": "47dead3f41f007c145e1b6a3a3236d0073529fa0f84becc646efdc563d7d1d7c"
-   }
-  }
+  "orig_nbformat": 4
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/formulaic/__init__.py
+++ b/formulaic/__init__.py
@@ -1,4 +1,4 @@
-from .formula import Formula, FormulaSpec
+from .formula import Formula, FormulaSpec, SimpleFormula, StructuredFormula
 from .materializers import FactorValues
 from .model_matrix import ModelMatrices, ModelMatrix
 from .model_spec import ModelSpec, ModelSpecs
@@ -19,6 +19,8 @@ __all__ = [
     "__version__",
     "__version_tuple__",
     "Formula",
+    "SimpleFormula",
+    "StructuredFormula",
     "FormulaSpec",
     "ModelMatrix",
     "ModelMatrices",

--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -1,26 +1,53 @@
 from __future__ import annotations
 
+import sys
+from abc import ABCMeta, abstractmethod
+from collections.abc import MutableSequence
 from enum import Enum
-from typing import Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
-from typing_extensions import TypeAlias
+from typing_extensions import Self, TypeAlias
+
+from formulaic.utils.sentinels import MISSING, _MissingType
 
 from .errors import FormulaInvalidError
 from .model_matrix import ModelMatrix
 from .parser import DefaultFormulaParser
 from .parser.types import FormulaParser, OrderedSet, Structured, Term
 from .utils.calculus import differentiate_term
+from .utils.deprecations import deprecated
 from .utils.variables import Variable, get_expression_variables
 
 FormulaSpec: TypeAlias = Union[
+    "Formula",
     str,
     List[Union[str, Term]],
     Set[Union[str, Term]],
-    Structured[Union[str, List[Term], Set[Term]]],
-    "Formula",  # Direct formula specification
     Dict[str, "FormulaSpec"],
-    Tuple["FormulaSpec", ...],  # Structured formulae
+    Tuple["FormulaSpec", ...],
+    Structured["FormulaSpec"],
 ]
+_SelfType = TypeVar("_SelfType", bound="Formula")
+
+
+DEFAULT_PARSER = DefaultFormulaParser()
+DEFAULT_NESTED_PARSER = DefaultFormulaParser(include_intercept=False)
 
 
 class OrderingMethod(Enum):
@@ -29,74 +56,90 @@ class OrderingMethod(Enum):
     SORT = "sort"
 
 
-class Formula(Structured[List[Term]]):
+class _FormulaMeta(ABCMeta):
     """
-    A Formula is a (potentially structured) list of terms, which is represented
-    by this class.
-
-    This is a thin wrapper around `Strucuted[List[Term]]` that adds convenience
-    methods for building model matrices from the formula (among other common
-    tasks). You can build a `Formula` instance by passing in a string for
-    parsing, or by manually assembling the terms yourself.
-
-    Examples:
-    ```
-    >>> Formula("y ~ x")
-    .lhs:
-        y
-    .rhs:
-        1 + x
-    >>> Formula("x + y", a=["x", "y:z"], b="y ~ z")
-    root:
-        1 + x + y
-    .a:
-        x + y:z
-    .b:
-        .lhs:
-            y
-        .rhs:
-            z
-    ```
-
-    You can control how strings are parsed into terms by passing in custom
-    parsers via `_parser` and `_nested_parser`.
-    ```
-    >>> Formula("y ~ x", _parser=DefaultFormulaParser(include_intercept=False))
-    .lhs:
-        y
-    .rhs:
-        x
-    ```
-
-    Attributes:
-        _parser: The `FormulaParser` instance to use when parsing complete
-            formulae (vs. individual terms). If not specified,
-            `DefaultFormulaParser()` is used.
-        _nested_parser: The `FormulaParser` instance to use when parsing
-            strings describing nested or individual terms (e.g. when `spec` is a
-            list of string term identifiers). If not specified and `_parser` is
-            specified, `_parser` is used; if `_parser` is not specified,
-            `DefaultFormulaParser(include_intercept=False)` is used instead.
-        _ordering: The ordering method to apply to the terms implied by the
-            formula `spec`. Can be: "none", "degree" (default), or "sort".
+    This metaclass serves two purposes:
+    (1) to allow the `Formula` class constructor to delegate in the construction
+        of either `SimpleFormula` or `StructuredFormula` subclass instances
+        based on the input specifications; without the `__init__` constuctor
+        being called twice.
+    (2) to provide the generic `.from_spec()` constructor that is only
+        accessible on the base classes, and not instances, of `Formula`.
     """
 
-    DEFAULT_PARSER = DefaultFormulaParser()
-    DEFAULT_NESTED_PARSER = DefaultFormulaParser(include_intercept=False)
+    def __call__(
+        cls,
+        root: Union[FormulaSpec, _MissingType] = MISSING,
+        *,
+        _ordering: Union[OrderingMethod, str] = OrderingMethod.DEGREE,
+        _parser: Optional[FormulaParser] = None,
+        _nested_parser: Optional[FormulaParser] = None,
+        **structure: FormulaSpec,
+    ) -> Formula:
+        """
+        Construct a `Formula` subclass instance based on the provided
+        specifications. If the resulting formula has no structure, a
+        `SimpleFormula` instance will be returned; otherwise, a
+        `StructuredFormula`.
 
-    __slots__ = ("_parser", "_nested_parser", "_ordering")
+        Some arguments a prefixed with underscores to prevent collision with
+        formula structure.
 
-    @classmethod
+        Args:
+            root: The (root) formula specification.
+            _parser: The `FormulaParser` instance to use when parsing complete
+                formulae (vs. individual terms). If not specified,
+                `DefaultFormulaParser()` is used.
+            _nested_parser: The `FormulaParser` instance to use when parsing
+                strings describing nested or individual terms (e.g. when `spec`
+                is a list of string term identifiers). If not specified and
+                `parser` is specified, `parser` is used; if `parser` is not
+                specified, `DefaultFormulaParser(include_intercept=False)` is
+                used instead.
+            _ordering: The ordering method to apply to the terms implied by the
+                formula `spec`. Can be: "none", "degree" (default), or "sort".
+            structure: Additional structure to be passed to the
+                `StructuredFormula` constructor.
+        """
+        if cls is not Formula:
+            self: Formula = cls.__new__(cls)  # type: ignore
+            self.__init__(  # type: ignore
+                root,
+                _ordering=_ordering,
+                _parser=_parser,
+                _nested_parser=_nested_parser,
+                **structure,
+            )
+            return self
+
+        if root is MISSING and not structure:
+            return SimpleFormula([])
+        if structure:
+            return StructuredFormula(
+                root,
+                _parser=_parser,
+                _nested_parser=_nested_parser,
+                _ordering=_ordering,
+                **structure,
+            )
+        return cls.from_spec(
+            cast(FormulaSpec, root),
+            ordering=_ordering,
+            parser=_parser,
+            nested_parser=_nested_parser,
+        )
+
     def from_spec(
         cls,
         spec: FormulaSpec,
         *,
+        ordering: Union[OrderingMethod, str] = OrderingMethod.DEGREE,
         parser: Optional[FormulaParser] = None,
         nested_parser: Optional[FormulaParser] = None,
-        ordering: Union[OrderingMethod, str] = OrderingMethod.DEGREE,
-    ) -> Formula:
+    ) -> Union[SimpleFormula, StructuredFormula]:
         """
-        Construct a `Formula` instance from a formula specification.
+        Construct a `SimpleFormula` or `StructuredFormula` instance from a
+        specification.
 
         Args:
             spec: The formula specification.
@@ -113,29 +156,539 @@ class Formula(Structured[List[Term]]):
                 formula `spec`. Can be: "none", "degree" (default), or "sort".
         """
         if isinstance(spec, Formula):
-            return spec
-        return Formula(
-            spec, _parser=parser, _nested_parser=nested_parser, _ordering=ordering
-        )
+            return cast(Union[SimpleFormula, StructuredFormula], spec)
 
+        nested_parser = nested_parser or parser or DEFAULT_NESTED_PARSER
+        parser = parser or DEFAULT_PARSER
+
+        if isinstance(spec, str):
+            spec = cast(
+                FormulaSpec,
+                (parser or DefaultFormulaParser()).get_terms(spec)._simplify(),
+            )
+
+        if isinstance(spec, dict):
+            return StructuredFormula(
+                _parser=parser, _nested_parser=nested_parser, _ordering=ordering, **spec
+            )
+        if isinstance(spec, Structured):
+            return StructuredFormula(
+                _ordering=ordering,
+                _parser=nested_parser,
+                _nested_parser=nested_parser,
+                **spec._structure,
+            )._simplify()
+        if isinstance(spec, tuple):
+            return StructuredFormula(
+                spec,
+                _ordering=ordering,
+                _parser=parser,
+                _nested_parser=nested_parser,
+            )._simplify()
+        if isinstance(spec, (list, set, OrderedSet)):
+            terms = [
+                term
+                for value in spec
+                for term in (
+                    nested_parser.get_terms(value)  # type: ignore[attr-defined]
+                    if isinstance(value, str)
+                    else [value]
+                )
+            ]
+            return SimpleFormula(terms, _ordering=ordering)
+        raise FormulaInvalidError(f"Unrecognized formula specification: {repr(spec)}.")
+
+
+class Formula(metaclass=_FormulaMeta):
+    """
+    The base class for all formulae represented by Formulaic. This class can be
+    directly instantiated, which will result in the construction of an
+    appropriate subclass instance (either `SimpleFormula` or
+    `StructuredFormula`), depending on whether the resulting formula has
+    structure or not.
+
+    The atomic element of all formulae is a `SimpleFormula`, which in turn is a
+    mutable sequence of arbitrarily many `Term` instances. `StructuredFormula`
+    allows the composition of multiple `SimpleFormula` instances into a
+    structured result.
+
+    Examples:
+    ```
+    >>> Formula("x")  # -> SimpleFormula
+    1 + x
+    >>> Formula("y ~ x")  # -> StructuredFormula
+    .lhs:
+        y
+    .rhs:
+        1 + x
+    >>> Formula("x + y", a=["x", "y:z"], b="y ~ z")  # -> StructuredFormula
+    root:
+        1 + x + y
+    .a:
+        x + y:z
+    .b:
+        .lhs:
+            y
+        .rhs:
+            z
+    ```
+
+    You can control how strings are parsed into formulae by passing in custom
+    parsers via `_parser` and `_nested_parser`. For example:
+    ```
+    >>> Formula("y ~ x", _parser=DefaultFormulaParser(include_intercept=False))
+    .lhs:
+        y
+    .rhs:
+        x
+    ```
+    """
+
+    @abstractmethod
     def __init__(
         self,
-        *args: FormulaSpec,
+        root: Union[FormulaSpec, _MissingType] = MISSING,
         _parser: Optional[FormulaParser] = None,
         _nested_parser: Optional[FormulaParser] = None,
         _ordering: Union[OrderingMethod, str] = OrderingMethod.DEGREE,
-        **kwargs: Any,
+        **structure: FormulaSpec,
     ):
-        self._parser = _parser or self.DEFAULT_PARSER
-        self._nested_parser = _nested_parser or _parser or self.DEFAULT_NESTED_PARSER
+        """
+        This constructor is never actually called, but documents the arguments
+        that should be used by all subclass constructors. These will be
+        dispatched to the appropriate subclass constructor via the metaclass
+        and/or `Formula.from_spec`.
+        """
+
+    @abstractmethod
+    def get_model_matrix(
+        self,
+        data: Any,
+        context: Optional[Mapping[str, Any]] = None,
+        drop_rows: Optional[Set[int]] = None,
+        **spec_overrides: Any,
+    ) -> Union[ModelMatrix, Structured[ModelMatrix]]:
+        """
+        Build the model matrix (or matrices) realisation of this formula for the
+        nominated `data`.
+
+        Args:
+            data: The data for which to build the model matrices.
+            context: An additional mapping object of names to make available in
+                when evaluating formula term factors.
+            drop_rows: An optional set of row indices to drop from the model
+                matrix. If specified, it will also be updated during
+                materialization with any additional rows dropped due to null
+                values.
+            spec_overrides: Any `ModelSpec` attributes to set/override. See
+                `ModelSpec` for more details.
+        """
+
+    @property
+    @abstractmethod
+    def required_variables(self) -> Set[Variable]:
+        """
+        The set of variables required in the data order to materialize this
+        formula.
+
+        Attempts are made to restrict these variables only to those expected in
+        the data, and not, for example, those associated with transforms and/or
+        values present in the evaluation namespace by default (e.g. `y ~ C(x)`
+        would include only `y` and `x`). This may not always be possible for
+        more advanced formulae that insert constants into the formula via the
+        evaluation context rather than the data context.
+        """
+
+    @abstractmethod
+    def differentiate(
+        self: _SelfType,
+        *wrt: str,
+        use_sympy: bool = False,
+    ) -> _SelfType:
+        """
+        EXPERIMENTAL: Take the gradient of this formula. When used a linear
+        regression, evaluating a trained model on model matrices generated by
+        this formula is equivalent to estimating the gradient of that fitted
+        form with respect to `wrt`.
+
+        Args:
+            wrt: The variables with respect to which the gradient should be
+                taken.
+            use_sympy: Whether to use sympy to perform symbolic differentiation.
+
+
+        Notes:
+            This method is provisional and may be removed in any future major
+            version.
+        """
+
+
+class SimpleFormula(
+    MutableSequence[Term] if sys.version_info >= (3, 9) else MutableSequence,  # type: ignore
+    Formula,
+):
+    """
+    The atomic component of all formulae represented by Formulaic, which in turn
+    is a mutable sequence of `Term` instances. `StructuredFormula` uses
+    `SimpleFormula` as its nodes.
+
+    Instances of this class can be used directly as a mutable sequence of
+    `Term`s, including indexing and iteration. Mutations to the sequence will
+    trigger reordering of the terms according to the specified ordering method.
+
+    Attributes:
+        ordering: The ordering method to use for the terms in this container (
+            passed as `_ordering` to the `SimpleFormula` constructor).
+
+    Note: This class' constructor is not intended to be called directly by users
+    in standard usage, and requires that the specification passed by users is
+    already a iterable sequence of `Term` instances. This class is not capable
+    of parsing formulae from strings, and will raise an error if a string is
+    passed.
+    """
+
+    def __init__(
+        self,
+        root: Union[Iterable[Term], _MissingType] = MISSING,
+        *,
+        _ordering: Union[OrderingMethod, str] = OrderingMethod.DEGREE,
+        _parser: Optional[FormulaParser] = None,
+        _nested_parser: Optional[FormulaParser] = None,
+        **structure: FormulaSpec,
+    ):
+        if root is MISSING:
+            root = ()
+        if isinstance(root, str) or not isinstance(root, Iterable):
+            raise FormulaInvalidError(
+                "`SimpleFormula` should be constructed from a list of `Term` instances, "
+                "not a string. To parse a formula string or other specifications, "
+                "please use `Formula` or `StructuredFormula` instead."
+            )
+        if structure:
+            raise FormulaInvalidError(
+                "`SimpleFormula` does not support nested structure. To create a "
+                "structured formula, use `StructuredFormula` instead."
+            )
+        self.__terms = list(root)
+        self.ordering = OrderingMethod(_ordering)
+
+        self.__validate_terms(self.__terms)
+
+        self._reorder()
+
+    @classmethod
+    def __validate_terms(cls, terms: Any) -> None:
+        """
+        Verify that `terms` is a valid sequence of `Term` instances.
+        """
+        if not all(isinstance(t, Term) for t in terms):
+            raise FormulaInvalidError(
+                f"All components of a `SimpleFormula` should be `Term` instances. Found: {repr(terms)}. To use formula strings, please use `Formula` or `StructuredFormula` instead."
+            )
+
+    def _reorder(self, ordering: Optional[OrderingMethod] = None) -> None:
+        """
+        Reorder the terms in this container in-place according to the specified
+        ordering method.
+
+        Args:
+            ordering: The ordering method to use for the terms in this container.
+                If not specified, the default ordering method for this container
+                is used.
+        """
+        ordering = OrderingMethod(ordering if ordering is not None else self.ordering)
+        orderer = None
+        if ordering is OrderingMethod.DEGREE:
+            orderer = lambda terms: sorted(terms, key=lambda term: term.degree)
+        elif ordering is OrderingMethod.SORT:
+            orderer = lambda terms: sorted(
+                [Term(factors=sorted(term.factors)) for term in terms]
+            )
+
+        if orderer is not None:
+            self.__terms = orderer(self.__terms)
+
+    # MutableSequence implementation
+
+    @overload
+    def __getitem__(self, key: int) -> Term: ...
+
+    @overload
+    def __getitem__(self, key: slice) -> SimpleFormula: ...
+
+    def __getitem__(self, key: Union[int, slice]) -> Union[Term, SimpleFormula]:
+        if isinstance(key, slice):
+            return self.__class__(self.__terms[key], _ordering=self.ordering)
+        else:
+            return self.__terms[key]
+
+    @overload
+    def __setitem__(self, key: int, value: Term) -> None: ...
+
+    @overload
+    def __setitem__(self, key: slice, value: Iterable[Term]) -> None: ...
+
+    def __setitem__(self, key, value):  # type: ignore
+        self.__validate_terms([value])
+        self.__terms[key] = value
+        self._reorder()
+
+    @overload
+    def __delitem__(self, key: int) -> None: ...
+
+    @overload
+    def __delitem__(self, key: slice) -> None: ...
+
+    def __delitem__(self, key):  # type: ignore
+        del self.__terms[key]
+
+    def __len__(self) -> int:
+        return len(self.__terms)
+
+    def insert(self, index: int, value: Term) -> None:
+        self.__validate_terms([value])
+        self.__terms.insert(index, value)
+        self._reorder()
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, SimpleFormula):
+            other = list(other)
+        if isinstance(other, list):
+            return self.__terms == other
+        return NotImplemented
+
+    # Transforms
+
+    def differentiate(  # pylint: disable=redefined-builtin
+        self,
+        *wrt: str,
+        use_sympy: bool = False,
+    ) -> SimpleFormula:
+        """
+        EXPERIMENTAL: Take the gradient of this formula. When used a linear
+        regression, evaluating a trained model on model matrices generated by
+        this formula is equivalent to estimating the gradient of that fitted
+        form with respect to `wrt`.
+
+        Args:
+            wrt: The variables with respect to which the gradient should be
+                taken.
+            use_sympy: Whether to use sympy to perform symbolic differentiation.
+
+
+        Notes:
+            This method is provisional and may be removed in any future major
+            version.
+        """
+        return SimpleFormula(
+            [
+                differentiate_term(term, wrt, use_sympy=use_sympy)
+                for term in self.__terms
+            ],
+            _ordering=self.ordering,
+        )
+
+    def get_model_matrix(
+        self,
+        data: Any,
+        context: Optional[Mapping[str, Any]] = None,
+        drop_rows: Optional[Set[int]] = None,
+        **spec_overrides: Any,
+    ) -> Union[ModelMatrix, Structured[ModelMatrix]]:
+        """
+        Build the model matrix (or matrices) realisation of this formula for the
+        nominated `data`.
+
+        Args:
+            data: The data for which to build the model matrices.
+            context: An additional mapping object of names to make available in
+                when evaluating formula term factors.
+            drop_rows: An optional set of row indices to drop from the model
+                matrix. If specified, it will also be updated during
+                materialization with any additional rows dropped due to null
+                values.
+            spec_overrides: Any `ModelSpec` attributes to set/override. See
+                `ModelSpec` for more details.
+        """
+        from .model_spec import ModelSpec
+
+        return ModelSpec.from_spec(self, **spec_overrides).get_model_matrix(
+            data, context=context, drop_rows=drop_rows
+        )
+
+    @property
+    def required_variables(self) -> Set[Variable]:
+        """
+        The set of variables required in the data order to materialize this
+        formula.
+
+        Attempts are made to restrict these variables only to those expected in
+        the data, and not, for example, those associated with transforms and/or
+        values present in the evaluation namespace by default (e.g. `y ~ C(x)`
+        would include only `y` and `x`). This may not always be possible for
+        more advanced formulae that insert constants into the formula via the
+        evaluation context rather than the data context.
+        """
+
+        variables: List[Variable] = [
+            variable
+            for term in self.__terms
+            for factor in term.factors
+            for variable in get_expression_variables(factor.expr, {})
+            if "value" in variable.roles
+        ]
+
+        # Filter out constants like `contr` that are already present in the
+        # TRANSFORMS namespace.
+        from formulaic.transforms import TRANSFORMS
+
+        return set(
+            filter(
+                lambda variable: variable.split(".", 1)[0] not in TRANSFORMS,
+                Variable.union(variables),
+            )
+        )
+
+    def __repr__(self) -> str:
+        return " + ".join([str(t) for t in self.__terms])
+
+    # Deprecated shims for legacy `Structured`-like behaviour (previously there
+    # was no distinction between `SimpleFormula` and `StructuredFormula`, and
+    # so it is possible that downstream libraries depend on these methods
+    # existing).
+
+    @property
+    @deprecated(
+        message="the `SimpleFormula.root` property is deprecated.",
+        as_of=(1, 1),
+        removed_in=(2, 0),
+    )
+    def root(self) -> Self:
+        return self
+
+    @property
+    @deprecated(
+        message="the `SimpleFormula._has_root` property is deprecated.",
+        as_of=(1, 1),
+        removed_in=(2, 0),
+    )
+    def _has_root(self) -> bool:
+        return True
+
+    @property
+    @deprecated(
+        message="the `SimpleFormula._has_structure` property is deprecated.",
+        as_of=(1, 1),
+        removed_in=(2, 0),
+    )
+    def _has_structure(self) -> bool:
+        return False
+
+    @deprecated(
+        message="the `SimpleFormula._map` method is deprecated.",
+        as_of=(1, 1),
+        removed_in=(2, 0),
+    )
+    def _map(
+        self,
+        func: Union[
+            Callable[[SimpleFormula], Any],
+            Callable[[SimpleFormula, Tuple[Union[str, int], ...]], Any],
+        ],
+        recurse: bool = True,
+        as_type: Optional[Type[Structured]] = None,
+        _context: Tuple[Union[str, int], ...] = (),
+    ) -> Any:
+        try:
+            return func(self, ())  # type: ignore
+        except TypeError:
+            return func(self)  # type: ignore
+
+    @deprecated(
+        message="the `SimpleFormula._flatten` method is deprecated.",
+        as_of=(1, 1),
+        removed_in=(2, 0),
+    )
+    def _flatten(self) -> Generator[SimpleFormula, None, None]:
+        yield self
+
+    @deprecated(
+        message="the `SimpleFormula._to_dict` method is deprecated.",
+        as_of=(1, 1),
+        removed_in=(2, 0),
+    )
+    def _to_dict(self) -> Dict[str, SimpleFormula]:
+        return {"root": self}
+
+    @deprecated(
+        message="the `SimpleFormula._simplify` method is deprecated.",
+        as_of=(1, 1),
+        removed_in=(2, 0),
+    )
+    def _simplify(
+        self, *, recurse: bool = True, unwrap: bool = True, inplace: bool = False
+    ) -> SimpleFormula:
+        return self
+
+    @deprecated(
+        message="the `SimpleFormula._update` method is deprecated.",
+        as_of=(1, 1),
+        removed_in=(2, 0),
+    )
+    def _update(self, root: Any = MISSING, **structure: Any) -> StructuredFormula:
+        return StructuredFormula(
+            root=self if root is MISSING else root, _ordering=self.ordering, **structure
+        )
+
+
+class StructuredFormula(Structured[SimpleFormula], Formula):
+    """
+    A container for structured formulae (formulae that have multiple nested
+    components; for example left- and right-hand sides in a regression formula).
+
+    This is a thin wrapper around `Structured[SimpleFormula]` that adds
+    convenience methods for building model matrices from the formula (among
+    other common tasks). You can build a `StructuredFormula` instance by
+    directly instantiating it, or by using the `Formula` constructor.
+
+    For more details on how to interact with structured formulae, refer to the
+    `Structured` docs, or the formulaic user-guides.
+
+    Attributes:
+        _parser: The `FormulaParser` instance to use when parsing complete
+            formulae (vs. individual terms). If not specified,
+            `DefaultFormulaParser()` is used.
+        _nested_parser: The `FormulaParser` instance to use when parsing
+            strings describing nested or individual terms (e.g. when `spec` is a
+            list of string term identifiers). If not specified and `_parser` is
+            specified, `_parser` is used; if `_parser` is not specified,
+            `DefaultFormulaParser(include_intercept=False)` is used instead.
+        _ordering: The ordering method to apply to the terms implied by the
+            formula specifications. Can be: "none", "degree" (default), or "sort".
+    """
+
+    __slots__ = ("_parser", "_nested_parser", "_ordering")
+
+    def __init__(
+        self,
+        root: Union[FormulaSpec, _MissingType] = MISSING,
+        _parser: Optional[FormulaParser] = None,
+        _nested_parser: Optional[FormulaParser] = None,
+        _ordering: Union[OrderingMethod, str] = OrderingMethod.DEGREE,
+        **structure: FormulaSpec,
+    ):
+        self._parser = _parser or DEFAULT_PARSER
+        self._nested_parser = _nested_parser or _parser or DEFAULT_NESTED_PARSER
         self._ordering = OrderingMethod(_ordering)
-        super().__init__(*args, **kwargs)
+        super().__init__(root, **structure)  # type: ignore
         self._simplify(unwrap=False, inplace=True)
 
-    def _prepare_item(self, key: str, item: FormulaSpec) -> Union[List[Term], Formula]:  # type: ignore[override]
+    def _prepare_item(  # type: ignore[override]
+        self, key: str, item: FormulaSpec
+    ) -> Union[SimpleFormula, StructuredFormula]:
         """
-        Convert incoming formula items into either a list of Terms or a nested
-        `Formula` instance.
+        Convert incoming formula items into either a `SimpleFormula` or a nested
+        `StructuredFormula` instance.
 
         Note: Where parsing of strings is required, the nested-parser is used
         except for the root element of the parent formula.
@@ -144,78 +697,14 @@ class Formula(Structured[List[Term]]):
             key: The structural key where the item will be stored.
             item: The specification to convert.
         """
-
-        formula_or_terms: Union[List[Term], Structured[List[Term]]]
-
-        if isinstance(item, str):
-            item = cast(
-                FormulaSpec,
-                (self._parser if key == "root" else self._nested_parser)
-                .get_terms(item)
-                ._simplify(),
-            )
-
-        if isinstance(item, Structured):
-            return cast(
-                Union[List[Term], Formula],
-                Formula(
-                    _parser=self._nested_parser,
-                    _ordering=self._ordering,
-                    **item._structure,
-                )._simplify(),
-            )
-        elif isinstance(item, (list, set, OrderedSet)):
-            formula_or_terms = [
-                term
-                for value in item
-                for term in (
-                    self._nested_parser.get_terms(value)  # type: ignore[attr-defined]
-                    if isinstance(value, str)
-                    else [value]
-                )
-            ]
-            self.__validate_terms(formula_or_terms)
-        else:
-            raise FormulaInvalidError(
-                f"Unrecognized formula specification: {repr(item)}."
-            )
-
-        # Order terms appropriately
-        orderer = None
-        if self._ordering is OrderingMethod.DEGREE:
-            orderer = lambda terms: sorted(terms, key=lambda term: term.degree)
-        elif self._ordering is OrderingMethod.SORT:
-            orderer = lambda terms: sorted(
-                [Term(factors=sorted(term.factors)) for term in terms]
-            )
-
-        if orderer is not None:
-            if isinstance(formula_or_terms, Structured):
-                formula_or_terms = formula_or_terms._map(orderer)
-            else:
-                formula_or_terms = orderer(formula_or_terms)
-
-        return cast(Union[List[Term], Formula], formula_or_terms)
-
-    @classmethod
-    def __validate_terms(cls, formula_or_terms: Any) -> None:
-        """
-        Verify that all terms are of the appropriate type. The acceptable types
-        are:
-            - List[Terms]
-            - Tuple[List[Terms], ...]
-            - Formula
-        """
-        if not isinstance(formula_or_terms, list):
-            # Should be impossible to reach this; here as a sentinel
-            raise FormulaInvalidError(
-                f"All components of a formula should be lists of `Term` instances. Found: {repr(formula_or_terms)}."
-            )
-        for term in formula_or_terms:
-            if not isinstance(term, Term):
-                raise FormulaInvalidError(
-                    f"All terms in formula should be instances of `formulaic.parser.types.Term`; received term {repr(term)} of type `{type(term)}`."
-                )
+        if isinstance(item, Formula):
+            return cast(Union[SimpleFormula, StructuredFormula], item)
+        return Formula.from_spec(
+            item,
+            ordering=self._ordering,
+            parser=(self._parser if key == "root" else self._nested_parser),
+            nested_parser=self._nested_parser,
+        )
 
     def get_model_matrix(
         self,
@@ -263,31 +752,16 @@ class Formula(Structured[List[Term]]):
 
         # Recurse through formula to collect all variables
         self._map(
-            lambda terms: variables.extend(
-                variable
-                for term in terms
-                for factor in term.factors
-                for variable in get_expression_variables(factor.expr, {})
-                if "value" in variable.roles
-            )
+            lambda formula: variables.extend(formula.required_variables),
         )
 
-        # Filter out constants like `contr` that are already present in the
-        # TRANSFORMS namespace.
-        from formulaic.transforms import TRANSFORMS
-
-        return set(
-            filter(
-                lambda variable: variable.split(".", 1)[0] not in TRANSFORMS,
-                Variable.union(variables),
-            )
-        )
+        return Variable.union(variables)
 
     def differentiate(  # pylint: disable=redefined-builtin
         self,
         *wrt: str,
         use_sympy: bool = False,
-    ) -> Formula:
+    ) -> SimpleFormula:
         """
         EXPERIMENTAL: Take the gradient of this formula. When used a linear
         regression, evaluating a trained model on model matrices generated by
@@ -305,29 +779,6 @@ class Formula(Structured[List[Term]]):
             version.
         """
         return cast(
-            Formula,
-            self._map(
-                lambda terms: [
-                    differentiate_term(term, wrt, use_sympy=use_sympy) for term in terms
-                ]
-            ),
+            SimpleFormula,
+            self._map(lambda formula: formula.differentiate(*wrt, use_sympy=use_sympy)),
         )
-
-    def __getattr__(self, attr: str) -> Any:
-        # Keep substructures wrapped to retain access to helper functions.
-        subformula = super().__getattr__(attr)
-        if attr != "root":
-            return Formula.from_spec(subformula, ordering="none")  # already ordered
-        return subformula
-
-    def __getitem__(self, key: Any) -> Any:
-        # Keep substructures wrapped to retain access to helper functions.
-        subformula = super().__getitem__(key)
-        if key != "root":
-            return Formula.from_spec(subformula, ordering="none")  # already ordered
-        return subformula
-
-    def __repr__(self, to_str: Callable[..., str] = repr) -> str:
-        if not self._has_structure and self._has_root:
-            return " + ".join([str(t) for t in self])
-        return str(self._map(lambda terms: " + ".join([str(t) for t in terms])))

--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -212,7 +212,7 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
         # This must happen before Step 1 otherwise the greedy rank reduction
         # below would result in a different outcome than if the columns had
         # always been in the generated order.
-        terms = self._cluster_terms(spec.formula.root, cluster_by=spec.cluster_by)
+        terms = self._cluster_terms(spec.formula, cluster_by=spec.cluster_by)
 
         # Step 1: Determine strategy to maintain structural full-rankness of output matrix
         # (reusing pre-generated structure if it is available)

--- a/formulaic/utils/deprecations.py
+++ b/formulaic/utils/deprecations.py
@@ -1,0 +1,31 @@
+import functools
+import warnings
+from typing import Callable, Optional, Tuple
+
+
+def deprecated(
+    func: Optional[Callable] = None,
+    *,
+    message: Optional[str] = None,
+    as_of: Optional[Tuple[int, ...]] = None,
+    removed_in: Optional[Tuple[int, ...]] = None,
+) -> Callable:
+    if func is None:
+        return functools.partial(
+            deprecated, message=message, as_of=as_of, removed_in=removed_in
+        )
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):  # type: ignore
+        warning = []
+        if as_of is not None:
+            warning.append(f"As of version {'.'.join(map(str, as_of))},")
+        warning.append(message or f"the `{func.__name__}` method is deprecated.")
+        if removed_in is not None:
+            warning.append(
+                f"This method will be removed in version {'.'.join(map(str, removed_in))}"
+            )
+        warnings.warn(" ".join(warning), DeprecationWarning, stacklevel=2)
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -420,7 +420,7 @@ class TestPandasMaterializer:
         o.seek(0)
         ms2 = pickle.load(o)
         assert isinstance(ms, Structured)
-        assert ms2.lhs.formula.root == ["a"]
+        assert ms2.lhs.formula == ["a"]
 
     def test_no_levels_encoding(self, data):
         mm = PandasMaterializer(data, output="pandas").get_model_matrix("a + D")

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -233,7 +233,7 @@ class TestModelSpec:
 
     def test_subset(self, model_spec, data2):
         subset = model_spec.subset(["a"])
-        assert subset.formula.root == ["a"]
+        assert subset.formula == ["a"]
         assert subset.variables == {"a"}
         assert numpy.allclose(
             model_spec.get_model_matrix(data2).values[:, model_spec.get_slice("a")],
@@ -241,7 +241,7 @@ class TestModelSpec:
         )
 
         subset = model_spec.subset(["a:A", "A"])
-        assert subset.formula.root == ["A", "a:A"]
+        assert subset.formula == ["A", "a:A"]
         assert subset.variables == {"a", "A"}
         assert numpy.allclose(
             model_spec.get_model_matrix(data2).values[
@@ -313,8 +313,8 @@ class TestModelSpec:
 
         mss = ms.subset("a ~ A")
 
-        assert mss.lhs.formula.root == ["a"]
-        assert mss.rhs.formula.root == ["1", "A"]
+        assert mss.lhs.formula == ["a"]
+        assert mss.rhs.formula == ["1", "A"]
 
         with pytest.raises(
             ValueError,
@@ -323,3 +323,11 @@ class TestModelSpec:
             ),
         ):
             ms.subset("a ~ A | A:a")
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Formula has no structure, and hence does not match the structure of the `ModelSpec` instance."
+            ),
+        ):
+            ms.subset("a + b")


### PR DESCRIPTION
This patch adds explicit classes for the structured and unstructured formula variants. I was on the fence about pulling the trigger on this, but the issues identified in #213 make the increase in local complexity worth it.

This is a largely backward compatible change, unless code is hard-coded to expect structured instance methods like `._map` and `_has_structure`. I doubt anyone is using them, but just in case, before merging I will add in backward compatible shims for these methods that raise the appropriate deprecation warnings; and ultimately we'll remove these shims in version 2.0 (whenever that happens). Users need never intentionally interact with the new `SimpleFormula` and `StructuredFormula` classes.

As a result of these changes, code like:
```
Formula(lhs=Formula(["y"]), rhs=Formula("1 + z:x + x + y + g:h", _ordering="none"))
```
will retain the ordering of the nested formulae rather than reordering them; due to the new distinction between `List[Term]` (which is still reordered according to the local ordering policy) and `SimpleFormula` which is responsible for its own ordering.

TODO:

* [x] Deprecated shims for `Structured` methods and attributes on the new `SimpleFormula` class.
* [x] Unit tests
* [x] Documentation

closes: #213 
