### PR TITLE
Associate `dict` and `recarray` types with `PandasMaterializer`.

### DIFF
--- a/tests/materializers/test_base.py
+++ b/tests/materializers/test_base.py
@@ -18,6 +18,8 @@ class TestFormulaMaterializer:
     def test_registrations(self):
         assert sorted(FormulaMaterializer.REGISTERED_NAMES) == ["arrow", "pandas"]
         assert sorted(FormulaMaterializer.REGISTERED_INPUTS) == [
+            "dict",
+            "numpy.rec.recarray",
             "pandas.DataFrame",
             "pandas.core.frame.DataFrame",
             "pyarrow.lib.Table",

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -117,6 +117,23 @@ class TestPandasMaterializer:
     def materializer(self, data):
         return PandasMaterializer(data)
 
+    def test_data_conversion(self):
+        df = PandasMaterializer({"a": [1, 2, 3]}).data
+        assert isinstance(df, pandas.DataFrame)
+        assert df.columns == ["a"]
+
+        df2 = PandasMaterializer({"a": 1}).data
+        assert isinstance(df2, pandas.DataFrame)
+        assert df2.columns == ["a"]
+        assert list(df2["a"]) == [1]
+
+        df3 = PandasMaterializer(
+            numpy.recarray((2,), dtype=[("x", int), ("y", float), ("z", int)])
+        ).data
+        assert isinstance(df3, pandas.DataFrame)
+        assert list(df3.columns) == ["x", "y", "z"]
+        assert len(df3["x"]) == 2
+
     @pytest.mark.parametrize("formula,tests", PANDAS_TESTS.items())
     def test_get_model_matrix(self, materializer, formula, tests):
         mm = materializer.get_model_matrix(formula, ensure_full_rank=True)


### PR DESCRIPTION
cc: @bashtage (for statsmodels and local convenience)