### PR TITLE
Drop support for Python 3.7 and 3.8.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -29,7 +29,7 @@ jobs:
           pip install hatch hatch-vcs
       - name: Run tests
         run: hatch run tests
-      - if: matrix.python-version == '3.7'
+      - if: matrix.python-version == '3.9'
         name: Check works with min requirements
         run: hatch run test_min:pytest tests
       - if: matrix.python-version == '3.9'

--- a/formulaic/model_matrix.py
+++ b/formulaic/model_matrix.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Tuple, TypeVar, cast
-
-try:
-    from typing import SupportsIndex
-except ImportError:  # pragma: no cover
-    from typing_extensions import SupportsIndex
-
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Optional,
+    SupportsIndex,
+    Tuple,
+    TypeVar,
+    cast,
+)
 
 import wrapt
 

--- a/formulaic/model_spec.py
+++ b/formulaic/model_spec.py
@@ -29,11 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .model_matrix import ModelMatrices, ModelMatrix
     from .transforms.contrasts import ContrastsState
 
-# Cached property was introduced in Python 3.8 (we currently support 3.7)
-try:
-    from functools import cached_property
-except ImportError:  # pragma: no cover
-    from cached_property import cached_property  # type: ignore
+from functools import cached_property
 
 
 @dataclass(frozen=True)

--- a/formulaic/parser/types/formula_parser.py
+++ b/formulaic/parser/types/formula_parser.py
@@ -5,6 +5,7 @@ from enum import IntEnum
 from typing import (
     Any,
     Iterable,
+    Literal,
     Mapping,
     MutableMapping,
     Optional,
@@ -12,8 +13,6 @@ from typing import (
     Union,
     overload,
 )
-
-from typing_extensions import Literal
 
 from formulaic.parser.types.ordered_set import OrderedSet
 from formulaic.utils.layered_mapping import LayeredMapping

--- a/formulaic/parser/types/operator_resolver.py
+++ b/formulaic/parser/types/operator_resolver.py
@@ -1,16 +1,11 @@
 import abc
 from collections import defaultdict
+from functools import cached_property
 from typing import Dict, Generator, Iterable, List, Tuple
 
 from ..utils import exc_for_token
 from .operator import Operator
 from .token import Token
-
-# Cached property was introduced in Python 3.8 (we currently support 3.7)
-try:
-    from functools import cached_property
-except ImportError:  # pragma: no cover
-    from cached_property import cached_property  # type: ignore
 
 
 class OperatorResolver(metaclass=abc.ABCMeta):

--- a/formulaic/transforms/cubic_spline.py
+++ b/formulaic/transforms/cubic_spline.py
@@ -33,11 +33,10 @@ The original license of the code is as follows:
 from __future__ import annotations
 
 from functools import partial
-from typing import Iterable, cast
+from typing import Iterable, Literal, cast
 
 import numpy
 import pandas
-from typing_extensions import Literal
 
 from formulaic.materializers.types import FactorValues
 from formulaic.transforms.basis_spline import SplineExtrapolation

--- a/formulaic/utils/code.py
+++ b/formulaic/utils/code.py
@@ -1,7 +1,6 @@
 import ast
 import keyword
 import re
-import sys
 from typing import MutableMapping, Union
 
 import numpy
@@ -11,18 +10,9 @@ from .iterators import peekable_iter
 # Expression formatting
 
 
-def format_expr(expr: Union[str, ast.AST]) -> str:  # pragma: no cover; branched code
-    if sys.version_info >= (3, 9):
-        code = ast.parse(expr, mode="eval") if isinstance(expr, str) else expr
-        return ast.unparse(code).replace("\n", " ")
-
-    import astor  # pylint: disable=import-error
-
-    # Note: We use `mode="exec"` here because `astor` inserts parentheses around
-    # expressions that cannot be naively removed. We still require that these
-    # are `eval`-uable in the `stateful_eval` method.
-    code = ast.parse(expr, mode="exec") if isinstance(expr, str) else expr
-    return astor.to_source(code).strip().replace("\n    ", "")
+def format_expr(expr: Union[str, ast.AST]) -> str:
+    code = ast.parse(expr, mode="eval") if isinstance(expr, str) else expr
+    return ast.unparse(code).replace("\n", " ")
 
 
 # Variable sanitization

--- a/formulaic/utils/constraints.py
+++ b/formulaic/utils/constraints.py
@@ -9,6 +9,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -19,7 +20,6 @@ from typing import (
 )
 
 import numpy
-from typing_extensions import Literal
 
 from formulaic.parser.algos.tokenize import tokenize
 from formulaic.parser.algos.tokens_to_ast import tokens_to_ast

--- a/formulaic/utils/layered_mapping.py
+++ b/formulaic/utils/layered_mapping.py
@@ -2,13 +2,8 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import MutableMapping
+from functools import cached_property
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
-
-# Cached property was introduced in Python 3.8 (we currently support 3.7)
-try:
-    from functools import cached_property
-except ImportError:  # pragma: no cover
-    from cached_property import cached_property  # type: ignore
 
 
 class LayeredMapping(MutableMapping):

--- a/formulaic/utils/sentinels.py
+++ b/formulaic/utils/sentinels.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Literal
 
-from typing_extensions import Literal, TypeAlias
+from typing_extensions import TypeAlias
 
 
 class Sentinel(Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,22 +18,17 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.7.2"
+requires-python = ">=3.9"
 dependencies = [
-    "astor>=0.8; python_version < \"3.9\"",
-    "cached-property>=1.3.0; python_version < \"3.8\"",
-    "graphlib-backport>=1.0.0; python_version < \"3.9\"",
     "interface-meta>=1.2.0",
-    "numpy>=1.16.5",
-    "pandas>=1.0",
+    "numpy>=1.20.0",
+    "pandas>=1.3",
     "scipy>=1.6",
     "wrapt>=1.0; python_version <\"3.13\"",
     "wrapt>=1.17.0rc1; python_version >=\"3.13\"",
@@ -81,22 +76,19 @@ dependencies = [
 tests = 'pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=formulaic --cov-report=xml -vv {args:tests}'
 
 [[tool.hatch.envs.test.matrix]]
-python = ["37", "38", "39", "310", "311", "312", "313"]
+python = ["39", "310", "311", "312", "313"]
 
 [[tool.hatch.envs.test_min.matrix]]
-python = ["37"]
+python = ["39"]
 
 [tool.hatch.envs.test_min]
 dependencies = [
     "formulaic[arrow,calculus]",
     "pytest==7.2.0",
     "pytest-cov==4.0.0",
-    "astor==0.8; python_version < \"3.9\"",
-    "cached-property==1.3.0; python_version < \"3.8\"",
-    "graphlib-backport==1.0.0; python_version < \"3.9\"",
     "interface-meta==1.2.0",
-    "numpy==1.16.5",
-    "pandas==1.0",
+    "numpy==1.20.0",
+    "pandas==1.3",
     "scipy==1.6",
     "wrapt==1.0",
     "typing-extensions==4.2.0",
@@ -116,7 +108,7 @@ omit = ["formulaic/_version.py"]
 # Linting configuration
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py39"
 
 exclude = [
     "*.egg-info",
@@ -162,7 +154,7 @@ ignore_missing_imports = true
 # Documentation configuration
 
 [tool.hatch.env]
-requires = ["hatch-pip-compile; python_version >= \"3.8\""]
+requires = ["hatch-pip-compile"]
 
 [tool.hatch.envs.docs]
 dependencies = [


### PR DESCRIPTION
These python releases are EOL.