### PR TITLE
Pin sparse output format to `csc` for consistency across all scipy versions.

### DIFF
--- a/formulaic/materializers/narwhals.py
+++ b/formulaic/materializers/narwhals.py
@@ -187,7 +187,7 @@ class NarwhalsMaterializer(FormulaMaterializer):
 
         # Otherwise, concatenate columns into model matrix
         if spec.output == "sparse":
-            return spsparse.hstack([col[1] for col in cols])
+            return spsparse.hstack([col[1] for col in cols], format="csc")
 
         # TODO: Can we do better than this? Having to reconstitute raw data
         # does not seem ideal.

--- a/formulaic/materializers/pandas.py
+++ b/formulaic/materializers/pandas.py
@@ -184,7 +184,7 @@ class PandasMaterializer(FormulaMaterializer):
 
         # Otherwise, concatenate columns into model matrix
         if spec.output == "sparse":
-            return spsparse.hstack([col[1] for col in cols])
+            return spsparse.hstack([col[1] for col in cols], format="csc")
         if spec.output == "numpy":
             return numpy.stack([col[1] for col in cols], axis=1)
         return pandas.DataFrame(


### PR DESCRIPTION
Upstream scipy `hstack` changed its default output format in our use-cases in Scipy 1.16, as indeed the API said it could... so this patch pins the output format to our desired `csc` format; fixing scipy 1.16 compatibility issues.

closes #250.