### PR TITLE
Fix misleading docs around passing in available variable overrides.

### DIFF
--- a/docsite/docs/guides/grammar.md
+++ b/docsite/docs/guides/grammar.md
@@ -127,4 +127,4 @@ and conventions of which you should be aware.
 [^6]: Implemented by an R package called [Formula](https://cran.r-project.org/web/packages/Formula/index.html) that extends the default formula syntax.
 [^7]: Patsy uses the `rescale` keyword rather than `scale`, but provides the same functionality.
 [^8]: For increased compatibility with patsy, we use patsy's signature for `standardize`.
-[^9]: Requires additional context to be passed in when directly using the `Formula` constructor. e.g. `Formula("y ~ .", context={"__formulaic_variables_available__": ["x", "y", "z"]})`; or you can use `model_matrix`, `ModelSpec.get_model_matrix()`, or `FormulaMaterializer.get_model_matrix()` without further specification.
+[^9]: Requires additional context to be passed in when directly using the `Formula` constructor. e.g. `Formula("y ~ .", _context={"__formulaic_variables_available__": ["x", "y", "z"]})`; or you can use `model_matrix`, `ModelSpec.get_model_matrix()`, or `FormulaMaterializer.get_model_matrix()` without further specification.

--- a/formulaic/sugar.py
+++ b/formulaic/sugar.py
@@ -22,7 +22,7 @@ def model_matrix(
     ```
     Formula(
         spec,
-        context={"__formulaic_variables_available__": ...},  # used for the `.` operator
+        _context={"__formulaic_variables_available__": ...},  # used for the `.` operator
     ).get_model_matrix(data, context=LayeredMapping(locals(), globals()), **kwargs)
     ```
     or


### PR DESCRIPTION
Previously the docs claimed that this should be passed in via the `context` rather than `_context` kwargs.

closes: #249 