### PR TITLE
Only indicate root variables in `required_variables`.

### DIFF
--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -533,24 +533,16 @@ class SimpleFormula(
         more advanced formulae that insert constants into the formula via the
         evaluation context rather than the data context.
         """
-
-        variables: list[Variable] = [
-            variable
-            for term in self.__terms
-            for factor in term.factors
-            for variable in get_expression_variables(factor.expr, {})
-            if "value" in variable.roles
-        ]
+        from formulaic.transforms import TRANSFORMS
 
         # Filter out constants like `contr` that are already present in the
         # TRANSFORMS namespace.
-        from formulaic.transforms import TRANSFORMS
-
-        return set(
-            filter(
-                lambda variable: variable.split(".", 1)[0] not in TRANSFORMS,
-                Variable.union(variables),
-            )
+        return Variable.union(
+            variable_root
+            for term in self.__terms
+            for factor in term.factors
+            for variable in get_expression_variables(factor.expr, {})
+            if (variable_root := variable.root) not in TRANSFORMS
         )
 
     def __repr__(self) -> str:

--- a/formulaic/model_spec.py
+++ b/formulaic/model_spec.py
@@ -420,7 +420,9 @@ class ModelSpec:
     def required_variables(self) -> set[Variable]:
         """
         The set of variables required to be in the data to materialize this
-        model specification.
+        model specification. Note that unlike `.variables`, this attribute
+        considers only the root variables (e.g. `a.fillna(0)` -> `a` vs.
+        `a.fillna`).
 
         If `.structure` has not been populated (which contains metadata about
         which columns where ultimate drawn from the data during
@@ -429,7 +431,7 @@ class ModelSpec:
         """
         if self.structure is None:
             return self.formula.required_variables
-        return self.variables_by_source.get("data", set())
+        return {v.root for v in self.variables_by_source.get("data", set())}
 
     def get_slice(self, columns_identifier: Union[int, str, Term, slice]) -> slice:
         """

--- a/formulaic/parser/types/token.py
+++ b/formulaic/parser/types/token.py
@@ -196,7 +196,8 @@ class Token:
         values present in the evaluation namespace by default (e.g. `y ~ C(x)`
         would include only `y` and `x`). This may not always be possible for
         more advanced formulae that insert constants into the formula via the
-        evaluation context rather than the data context.
+        evaluation context rather than the data context. We also only consider
+        the root variable (e.g. `a.fillna(0)` -> `a` vs. `a.fillna`).
         """
         if self.kind is Token.Kind.NAME:
             return {Variable(self.token)}
@@ -207,10 +208,9 @@ class Token:
                 from formulaic.transforms import TRANSFORMS
 
                 return set(
-                    filter(
-                        lambda variable: variable.split(".", 1)[0] not in TRANSFORMS,
-                        get_expression_variables(self.token),
-                    )
+                    variable.root
+                    for variable in get_expression_variables(self.token)
+                    if variable.split(".", 1)[0] not in TRANSFORMS
                 )
             except Exception:  # noqa: S110
                 pass

--- a/tests/parser/types/test_token.py
+++ b/tests/parser/types/test_token.py
@@ -99,5 +99,6 @@ class TestToken:
     def test_required_variables(self, token_a, token_b):
         assert token_a.required_variables == {"a"}
         assert token_b.required_variables == {"x"}
+        assert Token("a.fillna(0)", kind="python").required_variables == {"a"}
         assert Token("malformed((python", kind="python").required_variables == set()
         assert Token("xyz", kind="value").required_variables == set()

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -262,6 +262,7 @@ class TestFormula:
             "a",
             "b",
         }
+        assert Formula("a.fillna(0)").required_variables == {"a"}
         assert Formula("y ~ x").required_variables == {"x", "y"}
 
 


### PR DESCRIPTION
This resolves at least partially issues in #247 and #248.

```
import pandas
from formulaic import model_matrix

ms = model_matrix("a.fillna(0)", pandas.DataFrame({"a": [1,2, None]})).model_spec

ms.required_variables  # {"a"}
ms.variables # {"a.fillna"}

next(iter(ms.variables)).root # "a"
```