### PR TITLE
Avoid quoting in backticks factors with eval_method of type python.

### DIFF
--- a/formulaic/parser/types/factor.py
+++ b/formulaic/parser/types/factor.py
@@ -102,6 +102,6 @@ class Factor:
         return OrderedSet((Term([self]),))
 
     def __repr__(self) -> str:
-        if ":" in self.expr:
+        if ":" in self.expr and self.eval_method == Factor.EvalMethod.LOOKUP:
             return f"`{self.expr}`"
         return self.expr

--- a/tests/parser/types/test_factor.py
+++ b/tests/parser/types/test_factor.py
@@ -53,3 +53,4 @@ class TestFactor:
     def test_repr(self):
         assert repr(Factor("a")) == "a"
         assert repr(Factor("a:b")) == "`a:b`"
+        assert repr(Factor("a(lambda c: 1)", eval_method="python")) == "a(lambda c: 1)"


### PR DESCRIPTION
closes: #255 