### PR TITLE
highlight code snippets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It provides:
 
 ## Example code
 
-```
+```python
 import pandas
 from formulaic import Formula
 
@@ -112,7 +112,7 @@ y, X = Formula('y ~ x + z').get_model_matrix(df)
 
 Note that the above can be short-handed to:
 
-```
+```python
 from formulaic import model_matrix
 model_matrix('y ~ x + z', df)
 ```


### PR DESCRIPTION
Hi!

Looking through this project, I was a bit sad to see that the code snippets in the README weren't highlighted.

I think it makes things easier to read and a bit prettier.

Before:

<img width="1133" height="333" alt="image" src="https://github.com/user-attachments/assets/01d1a42b-1c87-4d20-8539-d93a6f4ff938" />


After:

<img width="922" height="322" alt="image" src="https://github.com/user-attachments/assets/b5032704-6bf8-4430-af87-5ace0b3f2443" />
