### PR TITLE
MAINT: Add support for pandas 3 StringDtype

### DIFF
--- a/formulaic/materializers/pandas.py
+++ b/formulaic/materializers/pandas.py
@@ -44,7 +44,7 @@ class PandasMaterializer(FormulaMaterializer):
 
     @override
     def _is_categorical(self, values: Any) -> bool:
-        pandas_dtypes = (pandas.CategoricalDtype,)
+        pandas_dtypes: tuple[type, ...] = (pandas.CategoricalDtype,)
         # pandas 3.0 changes object dtype to StringDtype for string data
         if PANDAS3:
             pandas_dtypes += (pandas.StringDtype,)

--- a/formulaic/materializers/pandas.py
+++ b/formulaic/materializers/pandas.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy
+import packaging.version
 import pandas
 import scipy.sparse as spsparse
 from interface_meta import override
@@ -17,6 +18,8 @@ from .base import FormulaMaterializer
 
 if TYPE_CHECKING:  # pragma: no cover
     from formulaic.model_spec import ModelSpec
+
+PANDAS3 = packaging.version.parse(pandas.__version__) > packaging.version.parse("2.99")
 
 
 class PandasMaterializer(FormulaMaterializer):
@@ -41,10 +44,12 @@ class PandasMaterializer(FormulaMaterializer):
 
     @override
     def _is_categorical(self, values: Any) -> bool:
+        pandas_dtypes = (pandas.CategoricalDtype,)
+        # pandas 3.0 changes object dtype to StringDtype for string data
+        if PANDAS3:
+            pandas_dtypes += (pandas.StringDtype,)
         if isinstance(values, (pandas.Series, pandas.Categorical)):
-            return values.dtype == object or isinstance(
-                values.dtype, pandas.CategoricalDtype
-            )
+            return values.dtype == object or isinstance(values.dtype, pandas_dtypes)
         return super()._is_categorical(values)
 
     @override

--- a/formulaic/materializers/pandas.py
+++ b/formulaic/materializers/pandas.py
@@ -19,7 +19,8 @@ from .base import FormulaMaterializer
 if TYPE_CHECKING:  # pragma: no cover
     from formulaic.model_spec import ModelSpec
 
-PANDAS3 = packaging.version.parse(pandas.__version__) > packaging.version.parse("2.99")
+pandas_version = packaging.version.parse(pandas.__version__)
+PANDAS3 = pandas_version >= packaging.version.parse("3.0.0.dev0")
 
 
 class PandasMaterializer(FormulaMaterializer):

--- a/formulaic/materializers/pandas.py
+++ b/formulaic/materializers/pandas.py
@@ -19,8 +19,7 @@ from .base import FormulaMaterializer
 if TYPE_CHECKING:  # pragma: no cover
     from formulaic.model_spec import ModelSpec
 
-pandas_version = packaging.version.parse(pandas.__version__)
-PANDAS3 = pandas_version >= packaging.version.parse("3.0.0.dev0")
+PANDAS_CATEGORICAL_TYPES = ("object", "str", "category")
 
 
 class PandasMaterializer(FormulaMaterializer):
@@ -45,12 +44,8 @@ class PandasMaterializer(FormulaMaterializer):
 
     @override
     def _is_categorical(self, values: Any) -> bool:
-        pandas_dtypes: tuple[type, ...] = (pandas.CategoricalDtype,)
-        # pandas 3.0 changes object dtype to StringDtype for string data
-        if PANDAS3:
-            pandas_dtypes += (pandas.StringDtype,)
         if isinstance(values, (pandas.Series, pandas.Categorical)):
-            return values.dtype == object or isinstance(values.dtype, pandas_dtypes)
+            return values.dtype in PANDAS_CATEGORICAL_TYPES
         return super()._is_categorical(values)
 
     @override

--- a/tests/materializers/test_base.py
+++ b/tests/materializers/test_base.py
@@ -7,7 +7,7 @@ import pytest
 from formulaic.errors import FactorEncodingError, FormulaMaterializerNotFoundError
 from formulaic.materializers.base import FormulaMaterializer
 from formulaic.materializers.narwhals import NarwhalsMaterializer
-from formulaic.materializers.pandas import PandasMaterializer
+from formulaic.materializers.pandas import PANDAS3, PandasMaterializer
 from formulaic.materializers.types import (
     EvaluatedFactor,
     FactorValues,
@@ -64,12 +64,14 @@ class TestFormulaMaterializer:
         ):
             FormulaMaterializer.for_data("str")
 
+        # pandas 3.0 changes DataFrame location pandas.DataFrame
+        submod = "" if PANDAS3 else "core.frame."
         with pytest.raises(
             FormulaMaterializerNotFoundError,
             match=re.escape(
-                "No materializer is available for input type 'pandas.core.frame.DataFrame' "
+                f"No materializer is available for input type 'pandas.{submod}DataFrame' "
                 "that also supports output type 'invalid_output'. Available output types "
-                "for 'pandas.core.frame.DataFrame' are: "
+                f"for 'pandas.{submod}DataFrame' are: "
             ),
         ):
             FormulaMaterializer.for_data(pandas.DataFrame(), output="invalid_output")

--- a/tests/materializers/test_base.py
+++ b/tests/materializers/test_base.py
@@ -7,7 +7,7 @@ import pytest
 from formulaic.errors import FactorEncodingError, FormulaMaterializerNotFoundError
 from formulaic.materializers.base import FormulaMaterializer
 from formulaic.materializers.narwhals import NarwhalsMaterializer
-from formulaic.materializers.pandas import PANDAS3, PandasMaterializer
+from formulaic.materializers.pandas import PandasMaterializer
 from formulaic.materializers.types import (
     EvaluatedFactor,
     FactorValues,
@@ -65,13 +65,12 @@ class TestFormulaMaterializer:
             FormulaMaterializer.for_data("str")
 
         # pandas 3.0 changes DataFrame location pandas.DataFrame
-        submod = "" if PANDAS3 else "core.frame."
         with pytest.raises(
             FormulaMaterializerNotFoundError,
-            match=re.escape(
-                f"No materializer is available for input type 'pandas.{submod}DataFrame' "
-                "that also supports output type 'invalid_output'. Available output types "
-                f"for 'pandas.{submod}DataFrame' are: "
+            match=(
+                r"No materializer is available for input type 'pandas\.[a-z\.]+DataFrame' "
+                r"that also supports output type 'invalid_output'\. Available output types "
+                r"for 'pandas\.[a-z\.]+DataFrame' are: "
             ),
         ):
             FormulaMaterializer.for_data(pandas.DataFrame(), output="invalid_output")

--- a/tests/materializers/test_pandas.py
+++ b/tests/materializers/test_pandas.py
@@ -15,15 +15,11 @@ from formulaic.errors import (
 )
 from formulaic.materializers import PandasMaterializer
 from formulaic.materializers.base import EncodedTermStructure
-from formulaic.materializers.pandas import PANDAS3
+from formulaic.materializers.pandas import PANDAS_CATEGORICAL_TYPES
 from formulaic.materializers.types import EvaluatedFactor, FactorValues, NAAction
 from formulaic.model_spec import ModelSpec
 from formulaic.parser.types import Factor
 from formulaic.utils.structured import Structured
-
-PANDAS_CATEGORICAL_DTYPES = [object, "category"]
-if PANDAS3:
-    PANDAS_CATEGORICAL_DTYPES += [pandas.StringDtype()]
 
 PANDAS_TESTS = {
     # '<formula>': (<full_rank_names>, <names>, <full_rank_null_names>, <null_rows>)
@@ -559,10 +555,7 @@ class TestPandasMaterializer:
         )
         assert data["x"].dtype == object
         assert isinstance(data["y"].dtype, pandas.CategoricalDtype)
-        if PANDAS3:
-            assert isinstance(data["z"].dtype, pandas.StringDtype)
-        else:
-            assert data["z"].dtype == object
+        assert data["z"].dtype in ("object", "str")  # Pandas 3+ uses "str"; previously was "object"
         mm = PandasMaterializer(data).get_model_matrix("x + y + z + 0")
         assert isinstance(mm, pandas.DataFrame)
         assert list(mm.columns) == ["x[a]", "x[b]", "y[T.d]", "z[T.f]"]


### PR DESCRIPTION
Allow StringDtyle data to be parsed as categoricals Fix location in test of pandas.DataFrame in pandas 3