### PR TITLE
Fix compatibility with `pandas>=3`.

### DIFF
--- a/formulaic/materializers/pandas.py
+++ b/formulaic/materializers/pandas.py
@@ -42,7 +42,7 @@ class PandasMaterializer(FormulaMaterializer):
     @override
     def _is_categorical(self, values: Any) -> bool:
         if isinstance(values, (pandas.Series, pandas.Categorical)):
-            return values.dtype == object or isinstance(
+            return values.dtype in ("object", "str") or isinstance(
                 values.dtype, pandas.CategoricalDtype
             )
         return super()._is_categorical(values)

--- a/tests/materializers/test_base.py
+++ b/tests/materializers/test_base.py
@@ -66,10 +66,10 @@ class TestFormulaMaterializer:
 
         with pytest.raises(
             FormulaMaterializerNotFoundError,
-            match=re.escape(
-                "No materializer is available for input type 'pandas.core.frame.DataFrame' "
-                "that also supports output type 'invalid_output'. Available output types "
-                "for 'pandas.core.frame.DataFrame' are: "
+            match=(
+                r"No materializer is available for input type 'pandas\.[a-z\.]+DataFrame' "
+                r"that also supports output type 'invalid_output'\. Available output types "
+                r"for 'pandas\.[a-z\.]+DataFrame' are: "
             ),
         ):
             FormulaMaterializer.for_data(pandas.DataFrame(), output="invalid_output")


### PR DESCRIPTION
This patch adds compatibility with pandas 3 string dtypes (and treats them as categorical, as per pandas 2 behaviour).

Thanks to @bashtage for noticing this incompatibility, and putting up PR #258. I made some simplifications, and needed to do a rebase, but couldn't push that to his branch, so put this PR up instead.

closes: #258 