### PR TITLE
Add support for interaction `i` transform (ala `fixest::i()`)

### DIFF
--- a/docsite/docs/guides/transforms.ipynb
+++ b/docsite/docs/guides/transforms.ipynb
@@ -235,8 +235,8 @@
     "\n",
     "In Formulaic, a stateful transform is just a regular callable object (typically\n",
     "a function) that has an attribute `__is_stateful_transform__` that is set to\n",
-    "`True`. Such callables will be passed up to three additional arguments by\n",
-    "formulaic if they are present in the callable signature:\n",
+    "`True`. Such callables will be passed additional arguments by formulaic if they\n",
+    "are present in the callable signature:\n",
     "\n",
     "* `_state`: The existing state or an empty dictionary that should be mutated\n",
     "    to record any additional state.\n",
@@ -245,9 +245,12 @@
     "    populated.\n",
     "* `_spec`: The current model spec being evaluated (or an empty `ModelSpec` if\n",
     "    being called outside of Formulaic's materialization routines).\n",
+    "* `_materializer`: The `FormulaMaterializer` instance for which the expression\n",
+    "    is being evaluated.\n",
+    "* `_context`: A mapping of the name to value for all the variables available\n",
+    "    in the formula evaluation context (including data column names).\n",
     "\n",
-    "Only `_state` is required, `_metadata` and `_spec` will only be passed in by \n",
-    "Formulaic if they are present in the callable signature."
+    "Typically all stateful transforms will use `_state`, but all are optional."
    ]
   },
   {

--- a/formulaic/materializers/base.py
+++ b/formulaic/materializers/base.py
@@ -641,6 +641,7 @@ class FormulaMaterializer(metaclass=FormulaMaterializerMeta):
                 {expr: metadata},
                 spec.transform_state,
                 spec,
+                materializer=self,
                 variables=variables,
             ),
             variables,

--- a/formulaic/transforms/__init__.py
+++ b/formulaic/transforms/__init__.py
@@ -7,6 +7,7 @@ from .contrasts import C, ContrastsRegistry, encode_contrasts
 from .cubic_spline import cyclic_cubic_spline, natural_cubic_spline
 from .hashed import hashed
 from .identity import identity
+from .interactions import i
 from .lag import lag
 from .patsy_compat import PATSY_COMPAT_TRANSFORMS
 from .poly import poly
@@ -21,6 +22,7 @@ __all__ = [
     "C",
     "encode_contrasts",
     "ContrastsRegistry",
+    "i",
     "lag",
     "poly",
     "center",
@@ -51,6 +53,7 @@ TRANSFORMS = {
     "contr": ContrastsRegistry,
     "I": identity,
     "hashed": hashed,
+    "i": i,
     # Patsy compatibility shims
     **PATSY_COMPAT_TRANSFORMS,
 }

--- a/formulaic/transforms/contrasts.py
+++ b/formulaic/transforms/contrasts.py
@@ -40,6 +40,7 @@ def C(
     *,
     levels: Optional[Iterable[str]] = None,
     spans_intercept: bool = True,
+    reduce_rank: Optional[bool] = None,
 ) -> FactorValues:
     """
     Mark data as being categorical, and optionally specify the contrasts to be
@@ -78,7 +79,7 @@ def C(
             values,
             contrasts=contrasts,
             levels=levels,
-            reduced_rank=reduced_rank,
+            reduced_rank=reduce_rank if reduce_rank is not None else reduced_rank,
             _state=encoder_state,
             _spec=model_spec,
         )
@@ -86,7 +87,7 @@ def C(
     return FactorValues(
         data,
         kind="categorical",
-        spans_intercept=spans_intercept,
+        spans_intercept=not reduce_rank and spans_intercept,
         encoder=encoder,
     )
 

--- a/formulaic/transforms/interactions.py
+++ b/formulaic/transforms/interactions.py
@@ -1,0 +1,101 @@
+from typing import TYPE_CHECKING, Any
+
+import narwhals.stable.v1 as narwhals
+
+from formulaic.materializers.types import FactorValues
+from formulaic.transforms import stateful_transform
+from formulaic.transforms.contrasts import C
+
+if TYPE_CHECKING:
+    from formulaic.model_spec import ModelSpec  # pragma: no cover
+
+
+@stateful_transform
+def i(*args, _spec=None, _materializer=None):
+    """The 'interaction' transform, which creates interaction terms between non-null
+    combinations of the input arguments"""
+
+    # TODO: Keep track of encoder state.
+
+    if len(args) == 0:
+        return {}
+
+    if not _materializer:
+        raise RuntimeError("The 'i' transform requires a materializer context")
+
+    def encoder(
+        values: dict[str, Any],
+        reduced_rank: bool,
+        drop_rows: list[int],
+        encoder_state: dict[str, Any],
+        model_spec: ModelSpec,
+    ) -> FactorValues:
+        required_terms = narwhals.DataFrame.from_dict(
+            {
+                arg.name: narwhals.from_native(
+                    arg,
+                    series_only=True,
+                )
+                for arg in args
+            }
+        ).unique().sort(list(values.keys()))
+
+        encoded = {}
+        categorical_factors = set()
+        for name, arg in values.items():
+            if isinstance(arg, FactorValues):
+                if arg.__formulaic_metadata__.encoder:
+                    encoded[name] = arg.__formulaic_metadata__.encoder(
+                        values=arg, reduced_rank=False, drop_rows=drop_rows, encoder_state={}, model_spec=_spec
+                    )
+                    if not narwhals.dependencies.is_into_series(encoded[name]):
+                        categorical_factors.add(name)
+                else:
+                    encoded[name] = arg
+            elif _materializer._is_categorical(arg):
+                categorical_factors.add(name)
+                encoded[name] = dict(
+                    C(arg).__formulaic_metadata__.encoder(
+                        arg, reduced_rank=False, drop_rows=drop_rows, encoder_state={}, model_spec=_spec
+                    )
+                )
+            else:
+                encoded[name] = arg
+
+        out = {}
+        for row in required_terms.iter_rows(named=True):
+            factors = []
+            for name, value in row.items():
+                if name in categorical_factors:
+                    if value not in encoded[name]:
+                        break
+                    factors.append(
+                        {
+                            getattr(values[name], "format", "{name}[{field}]").format(name=name, field=value): encoded[name][value]
+                        }
+                    )
+                else:
+                    factors.append({name: encoded[name]})
+            else:
+                out.update(
+                    _materializer._get_columns_for_term(
+                        factors=factors,
+                        spec=_spec,
+                    )
+                )
+
+        return FactorValues(
+            out,
+            format="{field}",
+            spans_intercept=False,
+        )
+
+    return FactorValues(
+        {
+            arg.name: arg
+            for arg in args
+        },
+        kind="categorical",
+        spans_intercept=False,
+        encoder=encoder,
+    )


### PR DESCRIPTION
This patch implements initial support for the `i()` operator, motivated by `pyfixest` use-cases. There are still some rough edges (and encoder state is not actually preserved), but this implementation should work in most cases. See attached Jupyter notebook for usage demos.

Note that this is not a 1:1 drop in for the fixest estimator, in particular:

* This implementation supports interactions of arbitrary order (e.g. `i(a,b,c,d,...)`)
* This implementation labels columns according to conventions set elsewhere in this package; e.g. `i(A, B)` might output columns with names like: `A[a]:B[g]`.
* Unlike normal interactions, there is no guarantee provided for structural full-rankness, and usage of the same column inside of and outside of the `i(...)` operator can result in linear dependence.
* Binning and "keep" values are provided by per feature transforms, rather than by `i` itself. For example: `i(bin(A, ab=['a', 'b']))` and `i(C(A, levels=['a', 'b']))`.
* The `ref` functionality is, for the time being, implemented by a `reduce_rank` argument passed to `C()`, as above for levels. I'm not sure I like that.

[i_operator.ipynb](https://github.com/user-attachments/files/24536942/i_operator.ipynb)

closes: #244 
closes: #263 
