### PR TITLE
Improve `required_variables` derivation for required fields and stateful transforms.

### DIFF
--- a/formulaic/formula.py
+++ b/formulaic/formula.py
@@ -25,7 +25,7 @@ from .parser.types import FormulaParser, OrderedSet, Term
 from .utils.calculus import differentiate_term
 from .utils.deprecations import deprecated
 from .utils.structured import Structured
-from .utils.variables import Variable, get_expression_variables
+from .utils.variables import Variable
 
 FormulaSpec: TypeAlias = Union[
     "Formula",
@@ -541,7 +541,7 @@ class SimpleFormula(
             variable_root
             for term in self.__terms
             for factor in term.factors
-            for variable in get_expression_variables(factor.expr, {})
+            for variable in factor.required_variables
             if (variable_root := variable.root) not in TRANSFORMS
         )
 

--- a/formulaic/parser/types/factor.py
+++ b/formulaic/parser/types/factor.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from formulaic.utils.variables import Variable, get_required_variables
+
 from .ordered_set import OrderedSet
 from .term import Term
 
@@ -100,6 +102,40 @@ class Factor:
         a single-element ordered set.
         """
         return OrderedSet((Term([self]),))
+
+    @property
+    def required_variables(self) -> set[Variable]:
+        """
+        The set of variables required to evaluate this token.
+
+        If this is a Python token, and the code is malformed and unable to be
+        parsed, an empty set is returned. The code will fail more gracefully
+        later on.
+
+        Attempts are made to restrict these variables only to those expected in
+        the data, and not, for example, those associated with transforms and/or
+        values present in the evaluation namespace by default (e.g. `y ~ C(x)`
+        would include only `y` and `x`). This may not always be possible for
+        more advanced formulae that insert constants into the formula via the
+        evaluation context rather than the data context. We also only consider
+        the root variable (e.g. `a.fillna(0)` -> `a` vs. `a.fillna`).
+        """
+        if self.eval_method == Factor.EvalMethod.LOOKUP:
+            return {Variable(self.expr, roles={Variable.Role.VALUE})}
+        if self.eval_method == Factor.EvalMethod.PYTHON:
+            from formulaic.transforms import TRANSFORMS
+
+            try:
+                # Filter out constants like `contr` that are already present in the
+                # TRANSFORMS namespace.
+                return set(
+                    variable.root
+                    for variable in get_required_variables(self.expr, TRANSFORMS)
+                    if variable.root not in TRANSFORMS
+                )
+            except Exception:  # noqa: S110
+                pass
+        return set()
 
     def __repr__(self) -> str:
         if ":" in self.expr and self.eval_method == Factor.EvalMethod.LOOKUP:

--- a/formulaic/parser/types/token.py
+++ b/formulaic/parser/types/token.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Mapping
 from enum import Enum
 from typing import Any, Optional, Union
 
-from formulaic.utils.variables import Variable, get_expression_variables
+from formulaic.utils.variables import Variable, get_required_variables
 
 from .factor import Factor
 from .ordered_set import OrderedSet
@@ -209,8 +209,8 @@ class Token:
 
                 return set(
                     variable.root
-                    for variable in get_expression_variables(self.token)
-                    if variable.split(".", 1)[0] not in TRANSFORMS
+                    for variable in get_required_variables(self.token, TRANSFORMS)
+                    if variable.root not in TRANSFORMS
                 )
             except Exception:  # noqa: S110
                 pass

--- a/formulaic/transforms/patsy_compat.py
+++ b/formulaic/transforms/patsy_compat.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 from typing import Any, Optional
 
 from formulaic.utils.stateful_transforms import stateful_transform
+from formulaic.utils.variables import Variable
 
 from .contrasts import (
     UNSET,
@@ -29,7 +30,11 @@ def Treatment(reference: Any = UNSET) -> TreatmentContrasts:
     return TreatmentContrasts(base=reference)
 
 
-@stateful_transform
+@stateful_transform(
+    get_required_variables=lambda variable, *args, **kwargs: (
+        Variable(variable, roles={Variable.Role.VALUE}),
+    )
+)
 def Q(variable: str, _context: Optional[Mapping[str, Any]] = None) -> Any:
     return _context.data[variable]  # type: ignore
 

--- a/formulaic/utils/code.py
+++ b/formulaic/utils/code.py
@@ -1,7 +1,7 @@
 import ast
 import keyword
 import re
-from collections.abc import MutableMapping
+from collections.abc import Container, MutableMapping
 from typing import Union
 
 import numpy
@@ -65,7 +65,9 @@ def sanitize_variable_names(
                 sanitized_expr.append(f"`{variable_name}")
             else:
                 next(expr_parts)
-                new_name = sanitize_variable_name(variable_name, env, template=template)
+                new_name = sanitize_variable_name(
+                    variable_name, env, reserved_names=aliases, template=template
+                )
                 aliases[new_name] = variable_name
                 sanitized_expr.append(f" {new_name} ")
         else:
@@ -75,7 +77,11 @@ def sanitize_variable_names(
 
 
 def sanitize_variable_name(
-    name: str, env: MutableMapping, *, template: str = "{}"
+    name: str,
+    env: MutableMapping,
+    *,
+    reserved_names: Container[str],
+    template: str = "{}",
 ) -> str:
     """
     Generate a valid Python variable name for variable identifier `name`.
@@ -98,7 +104,7 @@ def sanitize_variable_name(
 
     # Verify new name is not in env already, and if not add a random suffix.
     new_name = template.format(base_name)
-    while new_name in env:
+    while new_name in env or new_name in reserved_names:
         new_name = template.format(
             base_name
             + "_"

--- a/formulaic/utils/stateful_transforms.py
+++ b/formulaic/utils/stateful_transforms.py
@@ -1,7 +1,7 @@
 import ast
 import functools
 import inspect
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -18,7 +18,11 @@ if TYPE_CHECKING:
     from formulaic.model_spec import ModelSpec  # pragma: no cover
 
 
-def stateful_transform(func: Callable) -> Callable:
+def stateful_transform(
+    func: Optional[Callable] = None,
+    *,
+    get_required_variables: Optional[Callable[..., Iterable[Variable]]] = None,
+) -> Callable:
     """
     Transform a callable object into a stateful transform.
 
@@ -34,13 +38,28 @@ def stateful_transform(func: Callable) -> Callable:
     Stateful transforms are also transformed into single dispatches, allowing
     different implementations for incoming data types.
 
+    This can be used either as a bare decorator (`@stateful_transform`) or with
+    optional arguments (`@stateful_transform(...)`).
+
     Args:
         func: The function (or other callable) to be made into a stateful
             transform.
+        get_required_variables: An optional callable that reports the variables
+            required to evaluate the transform. If provided, it is attached to
+            the returned wrapper as `.get_required_variables` so that variable
+            extraction can be delegated to it. It should accept the same
+            arguments as the wrapped function, and return the appropriate
+            `Variable` instances as a sequence.
 
     Returns:
-        The stateful transform callable.
+        The stateful transform callable (or, when called with only keyword
+        arguments, a decorator that produces one).
     """
+    if func is None:
+        return functools.partial(
+            stateful_transform, get_required_variables=get_required_variables
+        )
+
     func = functools.singledispatch(func)
     params = set(inspect.signature(func).parameters.keys())
 
@@ -82,6 +101,9 @@ def stateful_transform(func: Callable) -> Callable:
         )
 
     wrapper.__is_stateful_transform__ = True  # type: ignore[attr-defined]
+    wrapper.get_required_variables = get_required_variables or (  # type: ignore[attr-defined]
+        lambda *args, **kwargs: ()
+    )
     return wrapper
 
 

--- a/formulaic/utils/variables.py
+++ b/formulaic/utils/variables.py
@@ -5,8 +5,9 @@ import ast
 from collections import deque
 from collections.abc import Iterable, Mapping
 from enum import Enum
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
+from formulaic.utils.code import format_expr, sanitize_variable_names
 from formulaic.utils.layered_mapping import LayeredMapping
 
 
@@ -60,6 +61,30 @@ class Variable(str):
         )
 
 
+def get_required_variables(
+    expr: Union[str, ast.AST],
+    context: Optional[Mapping] = None,
+) -> set[Variable]:
+    """
+    Extract the variables that are required to evaluate the nominated Python
+    expression.
+
+    This is similar to `get_expression_variables`, but will first sanitize the
+    expression as performed by `stateful_eval`, allowing it to extract variables
+    from malformed expressions (e.g. those containing non-Pythonic syntax like
+    `log(x)` or `x[1]`).
+
+    Args:
+        expr: The string or AST representing the python expression.
+        context: The context from which variable values will be looked up.
+    """
+    env = LayeredMapping(context)
+    aliases: dict[str, str] = {}
+    if isinstance(expr, str):
+        expr = sanitize_variable_names(expr, env, aliases)
+    return get_expression_variables(expr, env, aliases)
+
+
 def get_expression_variables(
     expr: Union[str, ast.AST],
     context: Optional[Mapping] = None,
@@ -67,6 +92,10 @@ def get_expression_variables(
 ) -> set[Variable]:
     """
     Extract the variables that are used in the nominated Python expression.
+
+    It is assumed that the expression is valid Python code. If this is not true,
+    use `get_required_variables` instead, which will first sanitize the
+    expression as performed by `stateful_eval`.
 
     Args:
         expr: The string or AST representing the python expression.
@@ -77,7 +106,7 @@ def get_expression_variables(
     """
     if isinstance(expr, str):
         expr = ast.parse(expr, mode="eval")
-    variables = _get_ast_node_variables(expr, aliases or {})
+    variables = _get_ast_node_variables(expr, context or {}, aliases or {})
 
     if isinstance(context, LayeredMapping):
         out = set()
@@ -88,12 +117,35 @@ def get_expression_variables(
     return set(variables)
 
 
-def _get_ast_node_variables(node: ast.AST, aliases: Mapping) -> list[Variable]:
+def _get_ast_node_variables(
+    node: ast.AST, env: Mapping, aliases: Mapping
+) -> list[Variable]:
+    from .stateful_transforms import _is_stateful_transform
+
     variables: list[Variable] = []
 
     todo = deque([node])
     while todo:
         node = todo.popleft()
+        if _is_stateful_transform(node, env):
+            # Allow stateful transforms to add further variables to the graph
+            # by evaluating their `<func>.get_required_variables()` method, if
+            # it exists. This allows stateful transforms that, e.g., parse
+            # variables from strings to register their dependence on these
+            # variables.
+            call = cast(ast.Call, node)
+            delegated = ast.Call(
+                func=ast.Attribute(
+                    value=call.func,
+                    attr="get_required_variables",
+                    ctx=ast.Load(),
+                ),
+                args=call.args,
+                keywords=call.keywords,
+            )
+            variables.extend(
+                eval(compile(format_expr(delegated), "", "eval"), {}, env)  # nosec
+            )
         if not isinstance(node, (ast.Call, ast.Attribute, ast.Name)):
             todo.extend(ast.iter_child_nodes(node))
             continue

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -264,6 +264,8 @@ class TestFormula:
         }
         assert Formula("a.fillna(0)").required_variables == {"a"}
         assert Formula("y ~ x").required_variables == {"x", "y"}
+        assert Formula("y ~ Q('x')").required_variables == {"x", "y"}
+        assert Formula("y ~ Q('x+!') + `z?!`").required_variables == {"x+!", "y", "z?!"}
 
 
 class TestSimpleFormula:

--- a/tests/utils/test_code.py
+++ b/tests/utils/test_code.py
@@ -1,0 +1,7 @@
+from formulaic.utils.code import sanitize_variable_names
+
+
+def test_sanitize_variable_names():
+    assert sanitize_variable_names("`1a`", {}, {}) == "_1a"
+    assert sanitize_variable_names("`a b`", {}, {}) == "a_b"
+    assert sanitize_variable_names("`z?!` + `z??`", {}, {}).startswith("z__  +  z___")


### PR DESCRIPTION
Previously, formulae like "C(`x!`) + Q('y')" would work for model matrix generation, but fail for `.required_variables` introspection. This patch resolves these issues, and also the issues reported in #266.

closes: #266